### PR TITLE
Add frr-metrics and frr-reloader to Openshift Dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -3,6 +3,10 @@ WORKDIR /metallb
 
 ADD . /metallb
 
+WORKDIR /metallb/frr-metrics
+RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o ./frr-metrics
+
+
 WORKDIR /metallb/controller
 RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o ./controller
 
@@ -11,7 +15,13 @@ WORKDIR /metallb/speaker
 RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -o ./speaker
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.10
-COPY --from=builder /metallb/controller/controller /metallb/speaker/speaker /
+COPY --from=builder /metallb/controller/controller /metallb/speaker/speaker \
+      /metallb/frr-reloader/frr-reloader.sh /metallb/frr-metrics/frr-metrics /
+
+# When running as non root and building in an environment that `umask` masks out
+# '+x' for others, it won't be possible to execute. Make sure all can execute,
+# just in case
+RUN chmod a+x /frr-reloader.sh
 
 LABEL io.k8s.display-name="Metallb" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a metallb plugin." \


### PR DESCRIPTION
We need to build the frr-metrics and add the frr-reloader for
the speakers to run frr.

This will fix the following CI error coming from the cp-reloader
container in the speaker pod:

`cp: can't stat '/frr-reloader.sh': No such file or directory`

