### PR TITLE
Bug 2040394: Controller: enqueue the failed configmap till services update

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -708,7 +708,7 @@ func TestControllerConfig(t *testing.T) {
 	}
 
 	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetConfig(l, &config.Config{}) != k8s.SyncStateErrorNoRetry {
+	if c.SetConfig(l, &config.Config{}) != k8s.SyncStateError {
 		t.Fatalf("SetConfig that deletes allocated IPs was accepted")
 	}
 
@@ -874,7 +874,7 @@ func TestControllerDualStackConfig(t *testing.T) {
 	}
 
 	// Now that an IP is allocated, removing the IP pool is not allowed.
-	if c.SetConfig(l, &config.Config{}) != k8s.SyncStateErrorNoRetry {
+	if c.SetConfig(l, &config.Config{}) != k8s.SyncStateError {
 		t.Fatalf("SetConfig that deletes allocated IPs was accepted")
 	}
 

--- a/controller/main.go
+++ b/controller/main.go
@@ -110,7 +110,7 @@ func (c *controller) SetConfig(l log.Logger, cfg *config.Config) k8s.SyncState {
 
 	if err := c.ips.SetPools(cfg.Pools); err != nil {
 		level.Error(l).Log("op", "setConfig", "error", err, "msg", "applying new configuration failed")
-		return k8s.SyncStateErrorNoRetry
+		return k8s.SyncStateError
 	}
 	c.config = cfg
 	return k8s.SyncStateReprocessAll


### PR DESCRIPTION
When edit configmap for existing service, the config was rejected and
not re-enqueued for reprocess when the service update takes place,
causing the service to stay in pending state till it get deleted
by k8s.

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>


