### PR TITLE
[release-4.9] Bug 2052549: L2: use externalips for speaker allocation

### DIFF
--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -136,7 +136,7 @@ func hasHealthyEndpoint(eps k8s.EpsOrSlices, filterNode func(*string) bool) bool
 	return false
 }
 
-func (c *bgpController) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices) string {
+func (c *bgpController) ShouldAnnounce(l log.Logger, name string, _ net.IP, svc *v1.Service, eps k8s.EpsOrSlices) string {
 	// Should we advertise?
 	// Yes, if externalTrafficPolicy is
 	//  Cluster && any healthy endpoint exists

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -39,9 +39,7 @@ func (c *layer2Controller) SetConfig(log.Logger, *config.Config) error {
 
 // usableNodes returns all nodes that have at least one fully ready
 // endpoint on them.
-// The speakers parameter is a map with the node name as key and the readiness
-// status as value (true means ready, false means not ready).
-// If the speakers map is nil, it is ignored.
+// The speakers parameter is a map containing all the nodes with active speakers.
 func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 	usable := map[string]bool{}
 	switch eps.Type {
@@ -52,7 +50,7 @@ func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 					continue
 				}
 				if speakers != nil {
-					if ready, ok := speakers[*ep.NodeName]; !ok || !ready {
+					if hasSpeaker := speakers[*ep.NodeName]; !hasSpeaker {
 						continue
 					}
 				}
@@ -72,7 +70,7 @@ func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 					continue
 				}
 				if speakers != nil {
-					if ready, ok := speakers[nodeName]; !ok || !ready {
+					if hasSpeaker := speakers[nodeName]; !hasSpeaker {
 						continue
 					}
 				}
@@ -93,14 +91,23 @@ func usableNodes(eps k8s.EpsOrSlices, speakers map[string]bool) []string {
 	return ret
 }
 
-func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, svc *v1.Service, eps k8s.EpsOrSlices) string {
-	nodes := usableNodes(eps, c.sList.UsableSpeakers())
-	// Sort the slice by the hash of node + service name. This
-	// produces an ordering of ready nodes that is unique to this
-	// service.
+func (c *layer2Controller) ShouldAnnounce(l log.Logger, name string, toAnnounce net.IP, svc *v1.Service, eps k8s.EpsOrSlices) string {
+	if !activeEndpointExists(eps) { // no active endpoints, just return
+		return "notOwner"
+	}
+	var nodes []string
+	if svc.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal {
+		nodes = usableNodes(eps, c.sList.UsableSpeakers())
+	} else {
+		nodes = nodesWithActiveSpeakers(c.sList.UsableSpeakers())
+	}
+	ipString := toAnnounce.String()
+	// Sort the slice by the hash of node + load balancer ips. This
+	// produces an ordering of ready nodes that is unique to all the services
+	// with the same ip.
 	sort.Slice(nodes, func(i, j int) bool {
-		hi := sha256.Sum256([]byte(nodes[i] + "#" + name))
-		hj := sha256.Sum256([]byte(nodes[j] + "#" + name))
+		hi := sha256.Sum256([]byte(nodes[i] + "#" + ipString))
+		hj := sha256.Sum256([]byte(nodes[j] + "#" + ipString))
 
 		return bytes.Compare(hi[:], hj[:]) < 0
 	})
@@ -130,4 +137,35 @@ func (c *layer2Controller) DeleteBalancer(l log.Logger, name, reason string) err
 func (c *layer2Controller) SetNode(log.Logger, *v1.Node) error {
 	c.sList.Rejoin()
 	return nil
+}
+
+// nodesWithActiveSpeakers returns the list of nodes with active speakers.
+func nodesWithActiveSpeakers(speakers map[string]bool) []string {
+	var ret []string
+	for node := range speakers {
+		ret = append(ret, node)
+	}
+	return ret
+}
+
+// activeEndpointExists returns true if at least one endpoint is active.
+func activeEndpointExists(eps k8s.EpsOrSlices) bool {
+	switch eps.Type {
+	case k8s.Eps:
+		for _, subset := range eps.EpVal.Subsets {
+			if len(subset.Addresses) > 0 {
+				return true
+			}
+		}
+	case k8s.Slices:
+		for _, slice := range eps.SlicesVal {
+			for _, ep := range slice.Endpoints {
+				if !k8s.IsConditionReady(ep.Conditions) {
+					continue
+				}
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-kit/kit/log"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type fakeSpeakerList struct {
@@ -81,9 +83,7 @@ func TestUsableNodes(t *testing.T) {
 			},
 			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1", "iris2"},
-		},
-
-		{
+		}, {
 			desc: "Two endpoints, same host",
 			eps: k8s.EpsOrSlices{
 				EpVal: &v1.Endpoints{
@@ -106,9 +106,7 @@ func TestUsableNodes(t *testing.T) {
 			},
 			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1"},
-		},
-
-		{
+		}, {
 			desc: "Two endpoints, same host, one is not ready",
 			eps: k8s.EpsOrSlices{
 				EpVal: &v1.Endpoints{
@@ -377,7 +375,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -426,7 +424,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -474,7 +472,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -506,11 +504,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -523,7 +518,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -555,11 +550,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-
-		{
-			desc:     "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -572,7 +564,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -606,11 +598,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, controller 2 should announce for both services",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, controller 1 should announce the second, controller 2 the first",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -623,14 +612,14 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -677,17 +666,14 @@ func TestShouldAnnounce(t *testing.T) {
 			},
 			c1ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
-				"10.20.30.2": "notOwner",
+				"10.20.30.2": "",
 			},
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
-				"10.20.30.2": "",
+				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, controller 2 should not announce for the service with the not ready endpoint",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, controller 2 should not announce for the service with the not ready endpoint",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -700,14 +686,14 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -762,11 +748,8 @@ func TestShouldAnnounce(t *testing.T) {
 				"10.20.30.1": "",
 				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -779,14 +762,14 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -843,11 +826,8 @@ func TestShouldAnnounce(t *testing.T) {
 				"10.20.30.1": "",
 				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -860,7 +840,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -896,11 +876,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -913,7 +890,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -949,11 +926,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 1 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -966,7 +940,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1004,11 +978,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1021,7 +992,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1059,11 +1030,8 @@ func TestShouldAnnounce(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1076,7 +1044,7 @@ func TestShouldAnnounce(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1132,8 +1100,8 @@ func TestShouldAnnounce(t *testing.T) {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
 			pool := c1.config.Pools[poolFor(c1.config.Pools, lbIP)]
-			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, test.balancer, svc, test.eps[lbIP_s])
-			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, test.balancer, svc, test.eps[lbIP_s])
+			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", lbIP, svc, test.eps[lbIP_s])
+			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "balancer", lbIP, svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -1197,7 +1165,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1241,11 +1209,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-
-		{
-			desc:     "One service, two endpoints, one host, neither endpoint is ready, no controller should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints, one host, neither endpoint is ready, no controller should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1258,7 +1223,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1302,10 +1267,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-		{
-			desc:     "One service, two endpoints across two hosts, controller2 should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints across two hosts, controller2 should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1318,7 +1281,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1362,11 +1325,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints across two hosts, neither endpoint is ready, no controllers should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1379,7 +1339,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1423,11 +1383,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-
-		{
-			desc:     "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
-			balancer: "test1",
+		}, {
+			desc: "One service, two endpoints across two hosts, controller 2 is not ready, controller 1 should announce",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1440,7 +1397,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1484,11 +1441,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, controller 2 should announce for both services",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, each controller should announce one service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1501,14 +1455,14 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -1579,17 +1533,14 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			},
 			c1ExpectedResult: map[string]string{
 				"10.20.30.1": "notOwner",
-				"10.20.30.2": "notOwner",
+				"10.20.30.2": "",
 			},
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
-				"10.20.30.2": "",
+				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, controller 2 should not announce for the service with the not ready endpoint",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 2, each controller should announce one service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1602,14 +1553,14 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -1686,11 +1637,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				"10.20.30.1": "",
 				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
-			balancer: "test1",
+		}, {
+			desc: "Two services each with two endpoints across across two hosts, one service has an endpoint not ready on controller 1, the other service has an endpoint not ready on controller 2. Each controller should announce for the service with the ready endpoint on that controller",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1703,14 +1651,14 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.2"),
 				},
@@ -1787,11 +1735,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				"10.20.30.1": "",
 				"10.20.30.2": "notOwner",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1804,7 +1749,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1863,11 +1808,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1880,7 +1822,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -1935,11 +1877,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -1952,7 +1891,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -2007,11 +1946,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 2 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 1 hosts two endpoints, one of which is not ready, controller 1 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -2024,7 +1960,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -2079,11 +2015,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			c2ExpectedResult: map[string]string{
 				"10.20.30.1": "",
 			},
-		},
-
-		{
-			desc:     "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
-			balancer: "test1",
+		}, {
+			desc: "One service with three endpoints across across two hosts, controller 2 hosts two endpoints, both of which are not ready, controller 1 should announce for the service",
 			config: &config.Config{
 				Pools: map[string]*config.Pool{
 					"default": {
@@ -2096,7 +2029,7 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 				{
 					Spec: v1.ServiceSpec{
 						Type:                  "LoadBalancer",
-						ExternalTrafficPolicy: "Cluster",
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 					},
 					Status: statusAssigned("10.20.30.1"),
 				},
@@ -2169,8 +2102,8 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 			lbIP := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
 			lbIP_s := lbIP.String()
 			pool := c1.config.Pools[poolFor(c1.config.Pools, lbIP)]
-			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, test.balancer, svc, test.eps[lbIP_s])
-			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, test.balancer, svc, test.eps[lbIP_s])
+			response1 := c1.protocols[pool.Protocol].ShouldAnnounce(l, "test1", lbIP, svc, test.eps[lbIP_s])
+			response2 := c2.protocols[pool.Protocol].ShouldAnnounce(l, "test1", lbIP, svc, test.eps[lbIP_s])
 			if response1 != test.c1ExpectedResult[lbIP_s] {
 				t.Errorf("%q: shouldAnnounce for controller 1 for service %s returned incorrect result, expected '%s', but received '%s'", test.desc, lbIP_s, test.c1ExpectedResult[lbIP_s], response1)
 			}
@@ -2183,4 +2116,154 @@ func TestShouldAnnounceEPSlices(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func TestClusterPolicy(t *testing.T) {
+	fakeSL := &fakeSpeakerList{
+		speakers: map[string]bool{
+			"iris1": true,
+			"iris2": true,
+		},
+	}
+	c1, err := newController(controllerConfig{
+		MyNode: "iris1",
+		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:  fakeSL,
+	})
+	if err != nil {
+		t.Fatalf("creating controller: %s", err)
+	}
+	c1.client = &testK8S{t: t}
+
+	c2, err := newController(controllerConfig{
+		MyNode: "iris2",
+		Logger: log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		SList:  fakeSL,
+	})
+	if err != nil {
+		t.Fatalf("creating controller: %s", err)
+	}
+	c2.client = &testK8S{t: t}
+
+	l := log.NewNopLogger()
+
+	cfg := &config.Config{
+		Pools: map[string]*config.Pool{
+			"default": {
+				Protocol: config.Layer2,
+				CIDR:     []*net.IPNet{ipnet("10.20.30.0/24")},
+			},
+		},
+	}
+
+	if c1.SetConfig(l, cfg) == k8s.SyncStateError {
+		t.Errorf("SetConfig failed")
+	}
+	if c2.SetConfig(l, cfg) == k8s.SyncStateError {
+		t.Errorf("SetConfig failed")
+	}
+
+	eps1 := k8s.EpsOrSlices{
+		SlicesVal: []*discovery.EndpointSlice{
+			{
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"2.3.4.5",
+						},
+						Topology: map[string]string{
+							"kubernetes.io/hostname": "iris1",
+						},
+						Conditions: discovery.EndpointConditions{
+							Ready: boolPtr(true),
+						},
+					},
+				},
+			},
+		},
+		Type: k8s.Slices,
+	}
+	eps2 := k8s.EpsOrSlices{
+		SlicesVal: []*discovery.EndpointSlice{
+			{
+				Endpoints: []discovery.Endpoint{
+					{
+						Addresses: []string{
+							"2.3.4.5",
+						},
+						Topology: map[string]string{
+							"kubernetes.io/hostname": "iris2",
+						},
+						Conditions: discovery.EndpointConditions{
+							Ready: boolPtr(true),
+						},
+					},
+				},
+			},
+		},
+		Type: k8s.Slices,
+	}
+	c1Found := false
+	c2Found := false
+
+	// Cluster policy doesn't care about the locality of the endpoint, as long as there is
+	// at least one endpoint active. Here we check that the distribution of the service happens
+	// in a way that only a speaker notifies it, and that the assignement is consistent with the
+	// service ip.
+	for i := 1; i < 256; i++ {
+		ip := fmt.Sprintf("10.20.30.%d", i)
+		svc1 := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc1",
+			},
+			Spec: v1.ServiceSpec{
+				Type:                  "LoadBalancer",
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+			},
+			Status: statusAssigned(ip),
+		}
+		svc2 := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "svc2",
+			},
+			Spec: v1.ServiceSpec{
+				Type:                  "LoadBalancer",
+				ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
+			},
+			Status: statusAssigned(ip),
+		}
+
+		lbIP := net.ParseIP(ip)
+		response1svc1 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc1, eps1)
+		response2svc1 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc1, eps1)
+
+		response1svc2 := c1.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc2, eps2)
+		response2svc2 := c2.protocols[config.Layer2].ShouldAnnounce(l, "test1", lbIP, svc2, eps2)
+
+		// We check that only one speaker announces the service, so their response must be different
+		if response1svc1 == response2svc1 {
+			t.Fatalf("Expected only one speaker to announce ip %s , got %s from speaker1, %s from speaker2", ip, response1svc1, response2svc1)
+		}
+		// Speakers must announce different services with the same ip as the same way
+		if response1svc1 != response1svc2 {
+			t.Fatalf("Expected both speakers announce svc1 and svc2 with ip %s consistently, got %s from speaker1 for svc1, %s from speaker1 for svc2", ip, response1svc1, response1svc2)
+		}
+		if response2svc1 != response2svc2 {
+			t.Fatalf("Expected both speakers announce svc1 and svc2 with ip %s consistently, got %s from speaker2 for svc1, %s from speaker2 for svc2", ip, response1svc1, response1svc2)
+		}
+
+		// we check that both speaker announce at least one service
+		if response1svc1 == "" {
+			c1Found = true
+		}
+		if response2svc1 == "" {
+			c2Found = true
+		}
+	}
+	if !c1Found {
+		t.Fatalf("All services assigned to speaker2")
+	}
+	if !c2Found {
+		t.Fatalf("All services assigned to speaker1")
+	}
 }

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -264,7 +264,7 @@ func (c *controller) SetBalancer(l gokitlog.Logger, name string, svc *v1.Service
 		return c.deleteBalancer(l, name, "internalError")
 	}
 
-	if deleteReason := handler.ShouldAnnounce(l, name, svc, eps); deleteReason != "" {
+	if deleteReason := handler.ShouldAnnounce(l, name, lbIP, svc, eps); deleteReason != "" {
 		return c.deleteBalancer(l, name, deleteReason)
 	}
 
@@ -367,7 +367,7 @@ func (c *controller) SetNode(l gokitlog.Logger, node *v1.Node) k8s.SyncState {
 // A Protocol can advertise an IP address.
 type Protocol interface {
 	SetConfig(gokitlog.Logger, *config.Config) error
-	ShouldAnnounce(gokitlog.Logger, string, *v1.Service, k8s.EpsOrSlices) string
+	ShouldAnnounce(gokitlog.Logger, string, net.IP, *v1.Service, k8s.EpsOrSlices) string
 	SetBalancer(gokitlog.Logger, string, net.IP, *config.Pool) error
 	DeleteBalancer(gokitlog.Logger, string, string) error
 	SetNode(gokitlog.Logger, *v1.Node) error


### PR DESCRIPTION
backport L2 part from #976