### PR TITLE
Bug 2056967: Speaker metrics: Bug fix: wrong label 

### DIFF
--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -40,6 +40,7 @@ import (
 	"go.universe.tf/metallb/e2etest/pkg/wget"
 	internalconfig "go.universe.tf/metallb/internal/config"
 	corev1 "k8s.io/api/core/v1"
+	pkgerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
@@ -388,7 +389,9 @@ var _ = ginkgo.Describe("L2", func() {
 			svc, _ := service.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", testservice.TrafficPolicyCluster)
 			defer func() {
 				err := cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
-				framework.ExpectNoError(err)
+				if !pkgerr.IsNotFound(err) {
+					framework.ExpectNoError(err)
+				}
 			}()
 
 			ginkgo.By("checking the metrics when a service is added")
@@ -464,6 +467,23 @@ var _ = ginkgo.Describe("L2", func() {
 				framework.ExpectError(err, fmt.Sprintf("metallb_speaker_announced present in node: %s", p.Spec.NodeName))
 			}
 
+			ginkgo.By("validating the speaker doesn't publish layer2 metrics after deleting the service")
+			err = cs.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+
+			gomega.Eventually(func() error {
+				speakerMetrics, err := metrics.ForPod(controllerPod, advSpeaker, metallb.Namespace)
+				if err != nil {
+					return err
+				}
+
+				err = metrics.ValidateGaugeValue(1, "metallb_speaker_announced", map[string]string{"node": advSpeaker.Spec.NodeName, "protocol": "layer2", "service": fmt.Sprintf("%s/%s", f.Namespace.Name, svc.Name)}, speakerMetrics)
+				if err == nil {
+					return fmt.Errorf("metallb_speaker_announced present in node: %s", advSpeaker.Spec.NodeName)
+				}
+
+				return nil
+			}, 1*time.Minute, 1*time.Second).Should(gomega.BeNil())
 		},
 			table.Entry("IPV4 - Checking service", "ipv4"),
 			table.Entry("IPV6 - Checking service", "ipv6"))

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -338,12 +338,15 @@ func (c *controller) deleteBalancer(l log.Logger, name, reason string) k8s.SyncS
 	}
 
 	for _, ip := range c.svcIPs[name] {
-		announcing.Delete(prometheus.Labels{
+		ok := announcing.Delete(prometheus.Labels{
 			"protocol": string(proto),
 			"service":  name,
 			"node":     c.myNode,
-			"ips":      ip.String(),
+			"ip":       ip.String(),
 		})
+		if !ok {
+			level.Error(l).Log("op", "deleteBalancer", "error", "failed to delete service metric", "service", name, "ip", ip.String())
+		}
 	}
 	delete(c.announced, name)
 	delete(c.svcIPs, name)


### PR DESCRIPTION
The speaker metrics wasn't updated with deleted services because we were using the wrong label to delete it.
