### PR TITLE
Bug 2059945: Move CI config files from dev-scripts repo

### DIFF
--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -1,0 +1,37 @@
+# MetalLB test env
+
+This scripts installs MetalLB into OCP, for test environment.
+
+## Prerequisites
+
+- Succeed to deploy OCP by dev-scripts (https://github.com/openshift-metal3/dev-scripts)
+- IPv4 is enabled (Currently we targets IPv4. v4v6 case, we only support IPv4 for now)
+
+## Quickstart
+
+Make sure that OCP is deployed by dev-scripts.
+
+To configure MetalLB clone this repo to dev-scripts and run:
+
+```
+$ cd <dev-scripts>/metallb/openshift-ci/
+$ ./deploy_metallb.sh
+```
+
+### Check MetalLB pod status
+
+```
+$ export KUBECONIFG=<dev-scripts>/ocp/<cluster name>/auth/kubeconfig
+$ oc get pod -n metallb-system
+```
+
+### Run E2E tests against development cluster
+
+The test suite will run the appropriate tests against the cluster.
+
+To run the E2E tests:
+
+```
+$ cd <dev-scripts>/metallb/openshift-ci/
+$ ./run_e2e.sh
+```

--- a/openshift-ci/common.sh
+++ b/openshift-ci/common.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+metallb_dir="$(dirname $(readlink -f $0))"
+source ${metallb_dir}/../../common.sh
+source ${metallb_dir}/../../network.sh

--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+metallb_dir="$(dirname $(readlink -f $0))"
+source ${metallb_dir}/common.sh
+
+METALLB_OPERATOR_REPO=${METALLB_OPERATOR_REPO:-"https://github.com/openshift/metallb-operator.git"}
+METALLB_OPERATOR_BRANCH=${METALLB_OPERATOR_BRANCH:-"main"}
+METALLB_IMAGE_BASE=${METALLB_IMAGE_BASE:-$(echo "${OPENSHIFT_RELEASE_IMAGE}" | sed -e 's/release/stable/g' | sed -e 's/@.*$//g')}
+METALLB_IMAGE_TAG=${METALLB_IMAGE_TAG:-"metallb"}
+METALLB_OPERATOR_IMAGE_TAG=${METALLB_OPERATOR_IMAGE_TAG:-"metallb-operator"}
+FRR_IMAGE_TAG=${FRR_IMAGE_TAG:-"metallb-frr"}
+export NAMESPACE=${NAMESPACE:-"metallb-system"}
+
+if [ ! -d ./metallb-operator ]; then
+	git clone ${METALLB_OPERATOR_REPO}
+	cd metallb-operator
+	git checkout ${METALLB_OPERATOR_BRANCH}
+	cd -
+fi
+cd metallb-operator
+
+# install yq v4 for metallb deployment
+go install -mod='' github.com/mikefarah/yq/v4@v4.13.3
+
+yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="SPEAKER_IMAGE").value|="'${METALLB_IMAGE_BASE}':'${METALLB_IMAGE_TAG}'"' ${metallb_dir}/metallb-operator-deploy/controller_manager_patch.yaml
+yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="CONTROLLER_IMAGE").value|="'${METALLB_IMAGE_BASE}':'${METALLB_IMAGE_TAG}'"' ${metallb_dir}/metallb-operator-deploy/controller_manager_patch.yaml
+yq e --inplace '.spec.template.spec.containers[0].env[] |= select (.name=="FRR_IMAGE").value|="'${METALLB_IMAGE_BASE}':'${FRR_IMAGE_TAG}'"' ${metallb_dir}/metallb-operator-deploy/controller_manager_patch.yaml
+
+PATH="${GOPATH}:${PATH}" ENABLE_OPERATOR_WEBHOOK=true KUSTOMIZE_DEPLOY_DIR="../metallb-operator-deploy" IMG="${METALLB_IMAGE_BASE}:${METALLB_OPERATOR_IMAGE_TAG}" make deploy
+
+oc apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+EOF
+
+oc adm policy add-scc-to-user privileged -n metallb-system -z speaker
+
+sudo ip route add 192.168.10.0/24 dev ${BAREMETAL_NETWORK_NAME}

--- a/openshift-ci/metallb-operator-deploy/controller_manager_patch.yaml
+++ b/openshift-ci/metallb-operator-deploy/controller_manager_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: SPEAKER_IMAGE
+              value: "quay.io/metallb/speaker:main"
+            - name: CONTROLLER_IMAGE
+              value: "quay.io/metallb/controller:main"
+            - name: METALLB_BGP_TYPE
+              value: "frr"
+            - name: FRR_IMAGE
+              value: "quay.io/frrouting/frr:stable_7.5"

--- a/openshift-ci/metallb-operator-deploy/kustomization.yaml
+++ b/openshift-ci/metallb-operator-deploy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../metallb-operator/config/webhook-on-openshift
+
+patchesStrategicMerge:
+- controller_manager_patch.yaml

--- a/openshift-ci/run_e2e.sh
+++ b/openshift-ci/run_e2e.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+
+metallb_dir="$(dirname $(readlink -f $0))"
+source ${metallb_dir}/common.sh
+
+# add firewalld rules
+sudo firewall-cmd --zone=libvirt --permanent --add-port=179/tcp
+sudo firewall-cmd --zone=libvirt --add-port=179/tcp
+sudo firewall-cmd --zone=libvirt --permanent --add-port=180/tcp
+sudo firewall-cmd --zone=libvirt --add-port=180/tcp
+# BFD control packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=3784/udp
+sudo firewall-cmd --zone=libvirt --add-port=3784/udp
+# BFD echo packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=3785/udp
+sudo firewall-cmd --zone=libvirt --add-port=3785/udp
+# BFD multihop packets
+sudo firewall-cmd --zone=libvirt --permanent --add-port=4784/udp
+sudo firewall-cmd --zone=libvirt --add-port=4784/udp
+
+# need to skip L2 metrics test because the pod that's running the tests is not in the
+# same subnet of the cluster nodes, so the arp request that's done in the test won't work.
+SKIP="\"L2 metrics\""
+if [ "${IP_STACK}" = "v4" ]; then
+	SKIP="$SKIP\|IPV6\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+elif [ "${IP_STACK}" = "v6" ]; then
+	SKIP="$SKIP\|IPV4\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV6=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
+elif [ "${IP_STACK}" = "v4v6" ]; then
+	SKIP="$SKIP\|IPV6"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+fi
+echo "Skipping ${SKIP}"
+
+pip3 install --user -r ./../dev-env/requirements.txt
+export PATH=${PATH}:${HOME}/.local/bin
+export CONTAINER_RUNTIME=podman
+export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
+inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
+	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
+	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
+	--skip="${SKIP}" --use-operator


### PR DESCRIPTION
Moving the logic from dev-scripts repo here allows us easy update when needed. In addition, every change done in the
scripts will be tested by OCP CI.

So far, every change we made in MetalLB dev-scripts wasn't tested since the CI in dev-scripts repo is not configured
to test MetalLB (this shouldn't be changed since dev-scripts are used by many CI lanes and MetalLB shouldn't affect them).
