### PR TITLE
Bug 2055386: When services share IP, modifying any service should fail instead of allocating newIP

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -883,3 +883,73 @@ func TestControllerDualStackConfig(t *testing.T) {
 		t.Fatalf("SetConfig that deletes the config was accepted")
 	}
 }
+
+func TestControllerSvcAdddressSharing(t *testing.T) {
+	k := &testK8S{t: t}
+	c := &controller{
+		ips:    allocator.New(),
+		client: k,
+	}
+	l := log.NewNopLogger()
+
+	// Set a config with some IPs. Still no allocation, not synced.
+	cfg := &config.Config{
+		Pools: map[string]*config.Pool{
+			"default": {
+				AutoAssign: true,
+				CIDR:       []*net.IPNet{ipnet("4.5.6.0/24")},
+			},
+		},
+	}
+	if c.SetConfig(l, cfg) == k8s.SyncStateError {
+		t.Fatalf("SetConfig failed")
+	}
+	c.MarkSynced(l)
+
+	// Configure svc1
+	svc1 := &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:                  "LoadBalancer",
+			ClusterIPs:            []string{"4.5.6.1"},
+			ExternalTrafficPolicy: "Local",
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolTCP,
+					Port:     3000,
+				},
+			},
+		},
+	}
+
+	if c.SetBalancer(l, "test1", svc1, k8s.EpsOrSlices{}) == k8s.SyncStateError {
+		t.Fatalf("SetBalancer failed")
+	}
+	gotSvc1 := k.gotService(svc1)
+	if len(gotSvc1.Status.LoadBalancer.Ingress) == 0 || gotSvc1.Status.LoadBalancer.Ingress[0].IP != "4.5.6.0" {
+		t.Fatal("svc1 didn't get an IP")
+	}
+	k.reset()
+	// Configure svc2 with IP sharing with svc1 and different port/protocol/ETP
+	svc2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"metallb.universe.tf/allow-shared-ip": "share",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Type:                  "LoadBalancer",
+			ClusterIPs:            []string{"4.5.6.1"},
+			ExternalTrafficPolicy: "Cluster",
+			Ports: []v1.ServicePort{
+				{
+					Protocol: v1.ProtocolUDP,
+					Port:     1000,
+				},
+			},
+		},
+		Status: statusAssigned([]string{"4.5.6.0"}),
+	}
+	if c.SetBalancer(l, "test2", svc2, k8s.EpsOrSlices{}) != k8s.SyncStateError {
+		t.Fatalf("SetBalancer did not fail")
+	}
+}

--- a/controller/service.go
+++ b/controller/service.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	v1 "k8s.io/api/core/v1"
 
+	"go.universe.tf/metallb/internal/allocator"
 	"go.universe.tf/metallb/internal/allocator/k8salloc"
 	"go.universe.tf/metallb/internal/ipfamily"
 )
@@ -94,6 +96,13 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		if err = c.ips.Assign(key, lbIPs, k8salloc.Ports(svc), k8salloc.SharingKey(svc), k8salloc.BackendKey(svc)); err != nil {
 			level.Info(l).Log("event", "clearAssignment", "error", err, "msg", "current IP not allowed by config, clearing")
 			c.clearServiceState(key, svc)
+			// Check if we cannot assign IP because services were sharing IP using
+			// "allow-shared-ip" annotation and one of them changed so instead of allocating
+			// new service IP we fail.
+			if errors.Is(err, allocator.ErrCannotShareKey) {
+				c.client.Errorf(svc, "svcCannotShareKey", "current IP not allowed by config:%s", err)
+				return false
+			}
 			lbIPs = []net.IP{}
 		}
 

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -62,6 +62,8 @@ func New() *Allocator {
 	}
 }
 
+var ErrCannotShareKey = errors.New("services can't share key")
+
 // SetPools updates the set of address pools that the allocator owns.
 func (a *Allocator) SetPools(pools map[string]*config.Pool) error {
 	// All the fancy sharing stuff only influences how new allocations
@@ -417,7 +419,7 @@ func (a *Allocator) checkSharing(svc string, ip string, ports []Port, sk *key) e
 				}
 			}
 			if len(otherSvcs) > 0 {
-				return fmt.Errorf("can't change sharing key for %q, address also in use by %s", svc, strings.Join(otherSvcs, ","))
+				return fmt.Errorf("can't change sharing key for %q, address also in use by %s: %w", svc, strings.Join(otherSvcs, ","), ErrCannotShareKey)
 			}
 		}
 


### PR DESCRIPTION
Users prefer seeing errors when modify services that are sharing the sameIP
using "allow-shared-ip" annotation than getting newly allocated serviceIP

Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>
