### PR TITLE
openshift-ci: change kustomize path

### DIFF
--- a/openshift-ci/metallb-operator-deploy/kustomization.yaml
+++ b/openshift-ci/metallb-operator-deploy/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../metallb-operator/config/webhook-on-openshift
+- ../metallb-operator/config/default
 
 patchesStrategicMerge:
 - controller_manager_patch.yaml


### PR DESCRIPTION
Due to the recent changes in metallb-operator (moving the webhooks to metallb) the deployment path should be updated.
