### PR TITLE
Revert "Add dependabot file to track go deps"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
This reverts commit 22bcca095fee736aca9d63aab2dd0220b8c8d70d.

We track of the dependencies upstream, and d/s only reflects them.
Dependabot just creates noise.