### PR TITLE
Bug 2089827: Refix backward compatibility patch

### DIFF
--- a/openshift-ci/run_e2e.sh
+++ b/openshift-ci/run_e2e.sh
@@ -63,8 +63,10 @@ metadata:
 EOF
 
 git clone -b ${BACKWARD_COMPATIBLE_RELEASE} ${METALLB_REPO}
+
+metallb_root=$(dirname $metallb_dir )
 # We need to invert the order as deleting a used bfd profile is not allowed.
-patch metallb/e2etest/pkg/config/update.go < "$metallb_dir"/e2etest/backwardcompatible/patchfile
+patch metallb/e2etest/pkg/config/update.go < "$metallb_root"/e2etest/backwardcompatible/patchfile
 
 rm -rf e2etest # we want to make sure we are not running current e2e by mistake
 cd metallb


### PR DESCRIPTION
The path of the file was not accurate, metallb_dir refers to
metallb/openshift_ci. We need to raise a level.

To cut me some slack, I did not see the error in the previous CI run because it was finishing before patching the file.
Temporarily removing the `-e` flag to see if patching finally works or not.