### PR TITLE
Bug 2099875: Disable metrics endpoint in controller-runtime

### DIFF
--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -124,9 +124,10 @@ func New(cfg *Config) (*Client, error) {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:         scheme,
-		Port:           9443, // TODO port only with controller, for webhooks
-		LeaderElection: false,
+		Scheme:             scheme,
+		Port:               9443, // TODO port only with controller, for webhooks
+		LeaderElection:     false,
+		MetricsBindAddress: "0", // Disable metrics endpoint of controller manager
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: map[client.Object]cache.ObjectSelector{
 				&metallbv1beta1.AddressPool{}:      namespaceSelector,


### PR DESCRIPTION
Controller-runtime is starting a metrics endpoint on port 8080 by default, and prevents the speaker from starting if the port
is in use. Disabling the metrics endpoint in controller-runtime for the time, we might want to enable these metrics in the future.