### PR TITLE
Bug 2100035: Fix MP BGP

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -138,10 +138,6 @@ var _ = ginkgo.Describe("BGP", func() {
 			func(svc *corev1.Service) {
 				testservice.DualStack(svc)
 			}),
-		table.Entry("DUALSTACK - force V6 only", ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses},
-			func(svc *corev1.Service) {
-				testservice.ForceV6(svc)
-			}),
 		table.Entry("IPV4 - request IPv4 via custom annotation", ipfamily.IPv4, []string{v4PoolAddresses},
 			func(svc *corev1.Service) {
 				testservice.WithSpecificIPs(svc, "192.168.10.100")

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -122,6 +122,12 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 					testservice.DualStack(svc)
 					testservice.ForceV6(svc)
 				}),
+			table.Entry("DUALSTACK - via both, advertising ipv4 only",
+				ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.DualStack(svc)
+					testservice.ForceV4(svc)
+				}),
 		)
 
 		table.DescribeTable("should propagate the localpreference and the communities to both ipv4 and ipv6 addresses",

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package bgptests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
+	"go.universe.tf/metallb/e2etest/pkg/frr"
+	"go.universe.tf/metallb/e2etest/pkg/k8s"
+	"go.universe.tf/metallb/e2etest/pkg/metallb"
+	testservice "go.universe.tf/metallb/e2etest/pkg/service"
+	metallbconfig "go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/ipfamily"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	frrconfig "go.universe.tf/metallb/e2etest/pkg/frr/config"
+	frrcontainer "go.universe.tf/metallb/e2etest/pkg/frr/container"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("BGP Multiprotocol", func() {
+	var cs clientset.Interface
+	var f *framework.Framework
+
+	emptyBGPAdvertisement := metallbv1beta1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "empty",
+		},
+	}
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentGinkgoTestDescription().Failed {
+			dumpBGPInfo(ReportPath, ginkgo.CurrentGinkgoTestDescription().TestText, cs, f)
+			k8s.DumpInfo(Reporter, ginkgo.CurrentGinkgoTestDescription().TestText)
+		}
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
+		err := ConfigUpdater.Clean()
+		framework.ExpectNoError(err)
+
+		for _, c := range FRRContainers {
+			err := c.UpdateBGPConfigFile(frrconfig.Empty)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	f = framework.NewDefaultFramework("bgp")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	ginkgo.Context("Multiprotocol", func() {
+		table.DescribeTable("should advertise both ipv4 and ipv6 addresses with", func(pairingFamily ipfamily.Family, poolAddresses []string, tweak testservice.Tweak) {
+			resources := metallbconfig.ClusterResources{
+				Pools: []metallbv1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "mp-test",
+						},
+						Spec: metallbv1beta1.IPAddressPoolSpec{
+							Addresses: poolAddresses,
+						},
+					},
+				},
+				Peers:   metallb.PeersForContainers(FRRContainers, pairingFamily),
+				BGPAdvs: []metallbv1beta1.BGPAdvertisement{emptyBGPAdvertisement},
+			}
+			err := ConfigUpdater.Update(resources)
+			framework.ExpectNoError(err)
+
+			for _, c := range FRRContainers {
+				err := frrcontainer.PairWithNodes(cs, c, pairingFamily, func(container *frrcontainer.FRR) {
+					container.MultiProtocol = frrconfig.MultiProtocolEnabled
+				})
+				framework.ExpectNoError(err)
+			}
+
+			svc, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb", tweak)
+			defer testservice.Delete(cs, svc)
+
+			allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			framework.ExpectNoError(err)
+
+			for _, c := range FRRContainers {
+				validateFRRPeeredWithAllNodes(cs, c, pairingFamily)
+			}
+			for _, c := range FRRContainers {
+				validateService(cs, svc, allNodes.Items, c)
+			}
+		},
+			table.Entry("DUALSTACK - via ipv4",
+				ipfamily.IPv4, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.DualStack(svc)
+				}),
+			table.Entry("DUALSTACK - via ipv6",
+				ipfamily.IPv6, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.DualStack(svc)
+				}),
+		)
+
+		table.DescribeTable("should propagate the localpreference and the communities to both ipv4 and ipv6 addresses",
+			func(ipFamily ipfamily.Family) {
+				emptyAdvertisement := metallbv1beta1.BGPAdvertisement{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "empty",
+					},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						IPAddressPools: []string{"bgp-with-no-advertisement"},
+					},
+				}
+
+				pool := metallbv1beta1.IPAddressPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "bgp-with-advertisement",
+						Labels: map[string]string{"test": "bgp-with-advertisement"},
+					},
+					Spec: metallbv1beta1.IPAddressPoolSpec{
+						Addresses: []string{"192.168.10.0/24",
+							"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18"},
+					},
+				}
+
+				resources := metallbconfig.ClusterResources{
+					Peers: metallb.PeersForContainers(FRRContainers, ipFamily),
+					Pools: []metallbv1beta1.IPAddressPool{pool},
+					BGPAdvs: []metallbv1beta1.BGPAdvertisement{
+						emptyAdvertisement,
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "advertisement"},
+							Spec: metallbv1beta1.BGPAdvertisementSpec{
+								LocalPref:      50,
+								Communities:    []string{CommunityNoAdv},
+								IPAddressPools: []string{"bgp-with-advertisement"},
+							},
+						},
+					},
+				}
+
+				for _, c := range FRRContainers {
+					err := frrcontainer.PairWithNodes(cs, c, ipFamily, func(container *frrcontainer.FRR) {
+						container.MultiProtocol = frrconfig.MultiProtocolEnabled
+					})
+					framework.ExpectNoError(err)
+				}
+
+				err := ConfigUpdater.Update(resources)
+				framework.ExpectNoError(err)
+
+				for _, c := range FRRContainers {
+					validateFRRPeeredWithAllNodes(cs, c, ipFamily)
+				}
+
+				svc, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "service-with-adv",
+					testservice.TrafficPolicyCluster,
+					testservice.DualStack)
+
+				defer testservice.Delete(cs, svc)
+
+				allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				framework.ExpectNoError(err)
+
+				for _, c := range FRRContainers {
+					validateService(cs, svc, allNodes.Items, c)
+					for _, ip := range svc.Status.LoadBalancer.Ingress {
+						ingressIP := e2eservice.GetIngressPoint(&ip)
+						Eventually(func() error {
+							addressFamily := ipfamily.ForAddress(net.ParseIP(ingressIP))
+							routes, err := frr.RoutesForCommunity(c, CommunityNoAdv, addressFamily)
+							if err != nil {
+								return err
+							}
+							if _, ok := routes[ingressIP]; !ok {
+								return fmt.Errorf("%s route not found for community %s", ingressIP, CommunityNoAdv)
+							}
+							// LocalPref check is only valid for iBGP sessions
+							if strings.Contains(c.Name, "ibgp") {
+								localPrefix, err := frr.LocalPrefForPrefix(c, ingressIP, addressFamily)
+								if err != nil {
+									return err
+								}
+								if localPrefix != 50 {
+									return fmt.Errorf("%s %s not matching local pref", c.Name, ingressIP)
+								}
+							}
+							return nil
+						}, 1*time.Minute, 1*time.Second).Should(BeNil())
+					}
+				}
+			},
+			table.Entry("with DUALSTACK via ipv4",
+				ipfamily.IPv4),
+			table.Entry("with DUALSTACK via ipv6",
+				ipfamily.IPv6),
+		)
+	})
+})

--- a/e2etest/bgptests/bgp_multiprotocol.go
+++ b/e2etest/bgptests/bgp_multiprotocol.go
@@ -116,6 +116,12 @@ var _ = ginkgo.Describe("BGP Multiprotocol", func() {
 					testservice.TrafficPolicyCluster(svc)
 					testservice.DualStack(svc)
 				}),
+			table.Entry("DUALSTACK - via both, advertising ipv6 only",
+				ipfamily.DualStack, []string{v4PoolAddresses, v6PoolAddresses}, func(svc *corev1.Service) {
+					testservice.TrafficPolicyCluster(svc)
+					testservice.DualStack(svc)
+					testservice.ForceV6(svc)
+				}),
 		)
 
 		table.DescribeTable("should propagate the localpreference and the communities to both ipv4 and ipv6 addresses",

--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -44,6 +44,7 @@ type FRR struct {
 	Ipv4           string
 	Ipv6           string
 	Network        string
+	MultiProtocol  config.MultiProtocol
 }
 
 type Config struct {
@@ -121,7 +122,7 @@ func PairWithNodes(cs clientset.Interface, c *FRR, ipFamily ipfamily.Family, mod
 	for _, m := range modifiers {
 		m(&config)
 	}
-	bgpConfig, err := frrconfig.BGPPeersForAllNodes(cs, config.NeighborConfig, config.RouterConfig, ipFamily)
+	bgpConfig, err := frrconfig.BGPPeersForAllNodes(cs, config.NeighborConfig, config.RouterConfig, ipFamily, config.MultiProtocol)
 	if err != nil {
 		return err
 	}

--- a/e2etest/pkg/frr/validation.go
+++ b/e2etest/pkg/frr/validation.go
@@ -47,9 +47,10 @@ func RoutesMatchNodes(nodes []v1.Node, route bgpfrr.Route, ipFamily ipfamily.Fam
 	for _, ip := range ips {
 		nodesIPs[ip] = struct{}{}
 	}
+
 	for _, h := range route.NextHops {
 		if _, ok := nodesIPs[h.String()]; !ok { // skipping neighbors that are not nodes
-			return fmt.Errorf("%s not found in nodes ips", h.String())
+			return fmt.Errorf("%s not found in nodes ips, %v", h.String(), nodesIPs)
 		}
 
 		delete(nodesIPs, h.String())
@@ -72,7 +73,7 @@ func BFDPeersMatchNodes(nodes []v1.Node, peers map[string]bgpfrr.BFDPeer, ipFami
 
 	for k := range peers {
 		if _, ok := nodesIPs[k]; !ok { // skipping neighbors that are not nodes
-			return fmt.Errorf("%s not found in nodes ips", k)
+			return fmt.Errorf("%s not found in nodes ips %v", k, nodesIPs)
 		}
 		delete(nodesIPs, k)
 	}

--- a/e2etest/pkg/service/tweak.go
+++ b/e2etest/pkg/service/tweak.go
@@ -15,6 +15,12 @@ func TrafficPolicyLocal(svc *corev1.Service) {
 	svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 }
 
+func ForceV4(svc *corev1.Service) {
+	f := corev1.IPFamilyPolicySingleStack
+	svc.Spec.IPFamilyPolicy = &f
+	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+}
+
 func ForceV6(svc *corev1.Service) {
 	f := corev1.IPFamilyPolicySingleStack
 	svc.Spec.IPFamilyPolicy = &f

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -54,25 +54,27 @@ ipv6 nht resolve-via-default
 route-map {{$n.Addr}}-in deny 20
 {{- range $a := .Advertisements }}
 {{- if not (eq $a.LocalPref 0)}}
-{{frrIPFamily $n.IPFamily}} prefix-list {{localPrefPrefixList $n $a.LocalPref}} permit {{$a.Prefix}}
+{{frrIPFamily $a.IPFamily}} prefix-list {{localPrefPrefixList $n $a.LocalPref}} permit {{$a.Prefix}}
 route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
-  match {{frrIPFamily $n.IPFamily}} address prefix-list {{localPrefPrefixList $n $a.LocalPref}}
+  match {{frrIPFamily $a.IPFamily}} address prefix-list {{localPrefPrefixList $n $a.LocalPref}}
   set local-preference {{$a.LocalPref}}
   on-match next
 {{- end }}
 {{- range $c := $a.Communities }}
-{{frrIPFamily $n.IPFamily}} prefix-list {{communityPrefixList $n $c}} permit {{$a.Prefix}}
+{{frrIPFamily $a.IPFamily}} prefix-list {{communityPrefixList $n $c}} permit {{$a.Prefix}}
 route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
-  match {{frrIPFamily $n.IPFamily}} address prefix-list {{communityPrefixList $n $c}}
+  match {{frrIPFamily $a.IPFamily}} address prefix-list {{communityPrefixList $n $c}}
   set community {{$c}} additive
   on-match next
 {{- end }}
 {{frrIPFamily $a.IPFamily}} prefix-list {{allowedPrefixList $n}} permit {{$a.Prefix}}
 {{- end }}
 route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
-  match {{frrIPFamily $n.IPFamily}} address prefix-list {{allowedPrefixList $n}}
-  on-match next
-{{frrIPFamily $n.IPFamily}} prefix-list {{allowedPrefixList $n}} deny any
+  match ip address prefix-list {{allowedPrefixList $n}}
+route-map {{$n.Addr}}-out permit {{counter $n.Addr}}
+  match ipv6 address prefix-list {{allowedPrefixList $n}}
+ip prefix-list {{allowedPrefixList $n}} deny any
+ipv6 prefix-list {{allowedPrefixList $n}} deny any
 {{- end }}
 {{- end }}
 

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -269,9 +269,6 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			}
 
 			family := ipfamily.ForAddress(adv.Prefix.IP)
-			if family != neighbor.IPFamily {
-				continue
-			}
 
 			communities := make([]string, 0)
 

--- a/internal/bgp/frr/parse.go
+++ b/internal/bgp/frr/parse.go
@@ -186,6 +186,7 @@ func ParseRoutes(vtyshRes string) (map[string]Route, error) {
 		for _, n := range frrRoutes {
 			r.LocalPref = n.LocalPref
 			r.Origin = n.Origin
+		out:
 			for _, h := range n.Nexthops {
 				ip := net.ParseIP(h.IP)
 				if ip == nil {
@@ -193,6 +194,11 @@ func ParseRoutes(vtyshRes string) (map[string]Route, error) {
 				}
 				if ip.To4() == nil && h.Scope == "link-local" {
 					continue
+				}
+				for _, current := range r.NextHops {
+					if ip.Equal(current) {
+						continue out
+					}
 				}
 				r.NextHops = append(r.NextHops, ip)
 			}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -23,8 +23,10 @@ route-map 10.2.2.254-out permit 3
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -8,8 +8,10 @@ route-map 10.2.2.254-in deny 20
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -8,8 +8,10 @@ route-map 10.2.2.254-in deny 20
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNonExistingPeer.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNonExistingPeer.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelector.golden
@@ -23,8 +23,10 @@ route-map 10.2.2.254-out permit 3
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 127.0.0.2-in deny 20
 route-map 127.0.0.2-out permit 1
   match ip address prefix-list 127.0.0.2-pl-ipv4
-  on-match next
+route-map 127.0.0.2-out permit 2
+  match ipv6 address prefix-list 127.0.0.2-pl-ipv4
 ip prefix-list 127.0.0.2-pl-ipv4 deny any
+ipv6 prefix-list 127.0.0.2-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
@@ -6,8 +6,10 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 127:0:0::2-in deny 20
 route-map 127:0:0::2-out permit 1
+  match ip address prefix-list 127:0:0::2-pl-ipv6
+route-map 127:0:0::2-out permit 2
   match ipv6 address prefix-list 127:0:0::2-pl-ipv6
-  on-match next
+ip prefix-list 127:0:0::2-pl-ipv6 deny any
 ipv6 prefix-list 127:0:0::2-pl-ipv6 deny any
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
@@ -6,8 +6,10 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10:2:2::254-in deny 20
 route-map 10:2:2::254-out permit 1
+  match ip address prefix-list 10:2:2::254-pl-ipv6
+route-map 10:2:2::254-out permit 2
   match ipv6 address prefix-list 10:2:2::254-pl-ipv6
-  on-match next
+ip prefix-list 10:2:2::254-pl-ipv6 deny any
 ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -14,8 +14,10 @@ ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 3
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -24,8 +24,10 @@ route-map 10.2.2.254-out permit 3
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 route-map 10.2.2.255-in deny 20
 ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
 route-map 10.2.2.255-out permit 1
@@ -46,8 +48,10 @@ route-map 10.2.2.255-out permit 3
 ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 4
   match ip address prefix-list 10.2.2.255-pl-ipv4
-  on-match next
+route-map 10.2.2.255-out permit 5
+  match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 ip prefix-list 10.2.2.255-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelector.golden
@@ -24,8 +24,10 @@ route-map 10.2.2.254-out permit 3
 ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 5
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 route-map 10.2.2.255-in deny 20
 ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 1
@@ -40,8 +42,10 @@ route-map 10.2.2.255-out permit 2
 ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 3
   match ip address prefix-list 10.2.2.255-pl-ipv4
-  on-match next
+route-map 10.2.2.255-out permit 4
+  match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 ip prefix-list 10.2.2.255-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
@@ -6,13 +6,17 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10:2:2::254-in deny 20
 route-map 10:2:2::254-out permit 1
+  match ip address prefix-list 10:2:2::254-pl-ipv6
+route-map 10:2:2::254-out permit 2
   match ipv6 address prefix-list 10:2:2::254-pl-ipv6
-  on-match next
+ip prefix-list 10:2:2::254-pl-ipv6 deny any
 ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
 route-map 10:4:4::255-in deny 20
 route-map 10:4:4::255-out permit 1
+  match ip address prefix-list 10:4:4::255-pl-ipv6
+route-map 10:4:4::255-out permit 2
   match ipv6 address prefix-list 10:4:4::255-pl-ipv6
-  on-match next
+ip prefix-list 10:4:4::255-pl-ipv6 deny any
 ipv6 prefix-list 10:4:4::255-pl-ipv6 deny any
 
 router bgp 100

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -7,13 +7,17 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 route-map 10.4.4.255-in deny 20
 route-map 10.4.4.255-out permit 1
   match ip address prefix-list 10.4.4.255-pl-ipv4
-  on-match next
+route-map 10.4.4.255-out permit 2
+  match ipv6 address prefix-list 10.4.4.255-pl-ipv4
 ip prefix-list 10.4.4.255-pl-ipv4 deny any
+ipv6 prefix-list 10.4.4.255-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -7,8 +7,10 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -7,13 +7,17 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
-  on-match next
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 ip prefix-list 10.2.2.254-pl-ipv4 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
 route-map 10.4.4.255-in deny 20
 route-map 10.4.4.255-out permit 1
   match ip address prefix-list 10.4.4.255-pl-ipv4
-  on-match next
+route-map 10.4.4.255-out permit 2
+  match ipv6 address prefix-list 10.4.4.255-pl-ipv4
 ip prefix-list 10.4.4.255-pl-ipv4 deny any
+ipv6 prefix-list 10.4.4.255-pl-ipv4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy


### PR DESCRIPTION
Found by an upstream user, we broke MP bgp support between 4.10 and 4.11, this is restoring it.
