### PR TITLE
Bug 2102673: fix frr start race condition

### DIFF
--- a/internal/bgp/frr/debounce_test.go
+++ b/internal/bgp/frr/debounce_test.go
@@ -3,21 +3,24 @@
 package frr
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
 
 const timer = 10 * time.Millisecond
+const failureTimer = 10 * time.Millisecond
 
 func TestDebounce(t *testing.T) {
 	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
-	dummyUpdate := func(config *frrConfig) {
+	dummyUpdate := func(config *frrConfig) error {
 		result <- config
+		return nil
 	}
 
 	reload := make(chan *frrConfig)
 	defer close(reload)
-	debouncer(dummyUpdate, reload, timer)
+	debouncer(dummyUpdate, reload, timer, failureTimer)
 	reload <- &frrConfig{Hostname: "1"}
 	reload <- &frrConfig{Hostname: "2"}
 	reload <- &frrConfig{Hostname: "3"}
@@ -41,6 +44,36 @@ func TestDebounce(t *testing.T) {
 	}
 	updated = <-result
 	if updated.Hostname != "5" {
+		t.Fatal("Config was not updated")
+	}
+}
+
+func TestDebounceRetry(t *testing.T) {
+	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	count := 0
+	dummyUpdate := func(config *frrConfig) error {
+		count++
+		if count <= 3 {
+			return fmt.Errorf("error")
+		}
+		result <- config
+		return nil
+	}
+
+	reload := make(chan *frrConfig)
+	defer close(reload)
+	debouncer(dummyUpdate, reload, timer, failureTimer)
+	reload <- &frrConfig{Hostname: "1"}
+	reload <- &frrConfig{Hostname: "2"}
+	if len(result) != 0 {
+		t.Fatal("received update before time")
+	}
+	time.Sleep(10 * failureTimer)
+	if len(result) != 1 {
+		t.Fatal("received extra updates", len(result))
+	}
+	updated := <-result
+	if updated.Hostname != "2" {
 		t.Fatal("Config was not updated")
 	}
 }

--- a/internal/bgp/frr/debounce_test.go
+++ b/internal/bgp/frr/debounce_test.go
@@ -18,12 +18,12 @@ func TestDebounce(t *testing.T) {
 		return nil
 	}
 
-	reload := make(chan *frrConfig)
+	reload := make(chan reloadEvent)
 	defer close(reload)
 	debouncer(dummyUpdate, reload, timer, failureTimer)
-	reload <- &frrConfig{Hostname: "1"}
-	reload <- &frrConfig{Hostname: "2"}
-	reload <- &frrConfig{Hostname: "3"}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "2"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "3"}}
 	if len(result) != 0 {
 		t.Fatal("received update before time")
 	}
@@ -35,9 +35,10 @@ func TestDebounce(t *testing.T) {
 	if updated.Hostname != "3" {
 		t.Fatal("Config was not updated")
 	}
-	reload <- &frrConfig{Hostname: "3"}
-	reload <- &frrConfig{Hostname: "4"}
-	reload <- &frrConfig{Hostname: "5"}
+
+	reload <- reloadEvent{config: &frrConfig{Hostname: "3"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "4"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "5"}}
 	time.Sleep(3 * timer)
 	if len(result) != 1 {
 		t.Fatal("received extra updates", len(result))
@@ -60,11 +61,12 @@ func TestDebounceRetry(t *testing.T) {
 		return nil
 	}
 
-	reload := make(chan *frrConfig)
+	reload := make(chan reloadEvent)
 	defer close(reload)
 	debouncer(dummyUpdate, reload, timer, failureTimer)
-	reload <- &frrConfig{Hostname: "1"}
-	reload <- &frrConfig{Hostname: "2"}
+
+	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
+	reload <- reloadEvent{config: &frrConfig{Hostname: "2"}}
 	if len(result) != 0 {
 		t.Fatal("received update before time")
 	}
@@ -74,6 +76,41 @@ func TestDebounceRetry(t *testing.T) {
 	}
 	updated := <-result
 	if updated.Hostname != "2" {
+		t.Fatal("Config was not updated")
+	}
+}
+
+func TestDebounceReuseOld(t *testing.T) {
+	result := make(chan *frrConfig, 10) // buffered to accomodate spurious rewrites
+	dummyUpdate := func(config *frrConfig) error {
+		result <- config
+		return nil
+	}
+
+	reload := make(chan reloadEvent)
+	defer close(reload)
+	debouncer(dummyUpdate, reload, timer, failureTimer)
+
+	reload <- reloadEvent{config: &frrConfig{Hostname: "1"}}
+	if len(result) != 0 {
+		t.Fatal("received update before time")
+	}
+	time.Sleep(3 * timer)
+	if len(result) != 1 {
+		t.Fatal("received extra updates", len(result))
+	}
+	updated := <-result
+	if updated.Hostname != "1" {
+		t.Fatal("Config was not updated")
+	}
+	// reload to see if the debouncer uses the old config
+	reload <- reloadEvent{useOld: true}
+	time.Sleep(3 * timer)
+	if len(result) != 1 {
+		t.Fatal("received extra updates", len(result))
+	}
+	updated = <-result
+	if updated.Hostname != "1" {
 		t.Fatal("Config was not updated")
 	}
 }

--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -292,6 +292,7 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 }
 
 var debounceTimeout = 500 * time.Millisecond
+var failureTimeout = time.Second * 5
 
 func NewSessionManager(l log.Logger, logLevel logging.Level) *sessionManager {
 	res := &sessionManager{
@@ -300,11 +301,11 @@ func NewSessionManager(l log.Logger, logLevel logging.Level) *sessionManager {
 		reloadConfig: make(chan *frrConfig),
 		logLevel:     logLevelToFRR(logLevel),
 	}
-	reload := func(config *frrConfig) {
-		generateAndReloadConfigFile(config, l)
+	reload := func(config *frrConfig) error {
+		return generateAndReloadConfigFile(config, l)
 	}
 
-	debouncer(reload, res.reloadConfig, debounceTimeout)
+	debouncer(reload, res.reloadConfig, debounceTimeout, failureTimeout)
 
 	reloadValidator(l)
 

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -656,7 +656,7 @@ func TestLoggingConfiguration(t *testing.T) {
 		t.Fatalf("Error while creating configuration: %s", err)
 	}
 
-	sessionManager.reloadConfig <- config
+	sessionManager.reloadConfig <- reloadEvent{config: config}
 	testCheckConfigFile(t)
 }
 
@@ -672,7 +672,7 @@ func TestLoggingConfigurationDebug(t *testing.T) {
 		t.Fatalf("Error while creating configuration: %s", err)
 	}
 
-	sessionManager.reloadConfig <- config
+	sessionManager.reloadConfig <- reloadEvent{config: config}
 	testCheckConfigFile(t)
 }
 
@@ -692,6 +692,6 @@ func TestLoggingConfigurationOverrideByEnvironmentVar(t *testing.T) {
 		t.Fatalf("Error while creating configuration: %s", err)
 	}
 
-	sessionManager.reloadConfig <- config
+	sessionManager.reloadConfig <- reloadEvent{config: config}
 	testCheckConfigFile(t)
 }


### PR DESCRIPTION
Making the interaction with FRR more robust introducing retries after failures in both the call of the reloader (if the pid is not there yet) and if we find that the interaction between the reloader and the container fails.