### PR TITLE
Bug 2102676: restore k8s events metrics

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("BGP", func() {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bgp_updates_total", map[string]string{"peer": addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bgp_updates_total", map[string]string{"peer": addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}
@@ -790,12 +790,12 @@ var _ = ginkgo.Describe("BGP", func() {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bfd_control_packet_input", map[string]string{"peer": peer.addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bfd_control_packet_input", map[string]string{"peer": peer.addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bfd_control_packet_output", map[string]string{"peer": peer.addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bfd_control_packet_output", map[string]string{"peer": peer.addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}
@@ -805,12 +805,12 @@ var _ = ginkgo.Describe("BGP", func() {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bfd_session_up_events", map[string]string{"peer": peer.addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bfd_session_up_events", map[string]string{"peer": peer.addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bfd_zebra_notifications", map[string]string{"peer": peer.addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bfd_zebra_notifications", map[string]string{"peer": peer.addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}
@@ -820,12 +820,12 @@ var _ = ginkgo.Describe("BGP", func() {
 							if peer.multihop {
 								echoVal = 0
 							}
-							err = metrics.ValidateCounterValue(echoVal, "metallb_bfd_echo_packet_input", map[string]string{"peer": peer.addr}, speakerMetrics)
+							err = metrics.ValidateCounterValue(metrics.GreaterThan(echoVal), "metallb_bfd_echo_packet_input", map[string]string{"peer": peer.addr}, speakerMetrics)
 							if err != nil {
 								return err
 							}
 
-							err = metrics.ValidateCounterValue(echoVal, "metallb_bfd_echo_packet_output", map[string]string{"peer": peer.addr}, speakerMetrics)
+							err = metrics.ValidateCounterValue(metrics.GreaterThan(echoVal), "metallb_bfd_echo_packet_output", map[string]string{"peer": peer.addr}, speakerMetrics)
 							if err != nil {
 								return err
 							}
@@ -859,7 +859,7 @@ var _ = ginkgo.Describe("BGP", func() {
 							return err
 						}
 
-						err = metrics.ValidateCounterValue(1, "metallb_bfd_session_down_events", map[string]string{"peer": peer.addr}, speakerMetrics)
+						err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_bfd_session_down_events", map[string]string{"peer": peer.addr}, speakerMetrics)
 						if err != nil {
 							return err
 						}

--- a/e2etest/l2tests/l2.go
+++ b/e2etest/l2tests/l2.go
@@ -478,17 +478,17 @@ var _ = ginkgo.Describe("L2", func() {
 					return err
 				}
 
-				err = metrics.ValidateCounterValue(1, "metallb_layer2_requests_received", map[string]string{"ip": ingressIP}, speakerMetrics)
+				err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_layer2_requests_received", map[string]string{"ip": ingressIP}, speakerMetrics)
 				if err != nil {
 					return err
 				}
 
-				err = metrics.ValidateCounterValue(1, "metallb_layer2_responses_sent", map[string]string{"ip": ingressIP}, speakerMetrics)
+				err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_layer2_responses_sent", map[string]string{"ip": ingressIP}, speakerMetrics)
 				if err != nil {
 					return err
 				}
 
-				err = metrics.ValidateCounterValue(1, "metallb_layer2_gratuitous_sent", map[string]string{"ip": ingressIP}, speakerMetrics)
+				err = metrics.ValidateCounterValue(metrics.GreaterThan(1), "metallb_layer2_gratuitous_sent", map[string]string{"ip": ingressIP}, speakerMetrics)
 				if err != nil {
 					return err
 				}

--- a/internal/k8s/controllers/config_controller.go
+++ b/internal/k8s/controllers/config_controller.go
@@ -129,6 +129,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	switch res {
 	case SyncStateError:
 		configStale.Set(1)
+		updateErrors.Inc()
 		level.Error(r.Logger).Log("controller", "ConfigReconciler", "metallb CRs and Secrets", dumpClusterResources(&resources), "event", "reload failed, retry")
 		return ctrl.Result{}, retryError
 	case SyncStateReprocessAll:
@@ -136,6 +137,7 @@ func (r *ConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		r.ForceReload()
 	case SyncStateErrorNoRetry:
 		configStale.Set(1)
+		updateErrors.Inc()
 		level.Error(r.Logger).Log("controller", "ConfigReconciler", "metallb CRs and Secrets", dumpClusterResources(&resources), "event", "reload failed, no retry")
 		return ctrl.Result{}, nil
 	}

--- a/internal/k8s/controllers/stats.go
+++ b/internal/k8s/controllers/stats.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier:Apache-2.0
 
-package k8s
+package controllers
 
 import "github.com/prometheus/client_golang/prometheus"
 


### PR DESCRIPTION
In migrating to CRDs, we omitted filling the metrics related to k8s events. Here we re introduce them.