### PR TITLE
Bug 2107516: L2: add ndp responders when the address is v6 only

### DIFF
--- a/internal/layer2/announcer.go
+++ b/internal/layer2/announcer.go
@@ -95,7 +95,7 @@ func (a *Announce) updateInterfaces() {
 			if ipaddr.IP.To4() != nil && (ifi.Flags&net.FlagBroadcast) != 0 {
 				keepARP[ifi.Index] = true
 			}
-			if ipaddr.IP.IsLinkLocalUnicast() {
+			if ipaddr.IP.To4() == nil && ipaddr.IP.IsLinkLocalUnicast() {
 				keepNDP[ifi.Index] = true
 			}
 		}


### PR DESCRIPTION
A regression introduced by
https://github.com/metallb/metallb/pull/1347, we were adding records to
the keepNDP map regardless of the fact that a v6 address was present on
the interface.
Here we enforce the if checking that the ip is not v4.
