### PR TITLE
openshift-ci: Fix wait for build index container loop

### DIFF
--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -83,6 +83,7 @@ do
           success=1
           break
    fi
+   iterations=$((iterations+1))
    sleep $sleep_time
 done
 
@@ -108,7 +109,7 @@ do
        pod_name=$(oc -n openshift-marketplace get pod | grep metallbindex | awk '{print $1}')
        oc -n openshift-marketplace delete po $pod_name
    fi
-
+   iterations=$((iterations+1))
    sleep $sleep_time
 done
 

--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -38,6 +38,8 @@ find . -type f -name "*clusterserviceversion*.yaml" -exec sed -r -i 's/name: met
 
 cd -
 
+oc label ns openshift-marketplace --overwrite pod-security.kubernetes.io/enforce=privileged
+
 secret=$(oc -n openshift-marketplace get sa builder -oyaml | grep imagePullSecrets -A 1 | grep -o "builder-.*")
 
 buildindexpod="apiVersion: v1
@@ -121,6 +123,8 @@ else
 fi
 
 ./wait-for-csv.sh
+
+oc label ns openshift-marketplace --overwrite pod-security.kubernetes.io/enforce=baseline
 
 oc apply -f - <<EOF
 apiVersion: metallb.io/v1beta1


### PR DESCRIPTION
We were not increasing the number of iterations, causing an infinite loop.

Also allow running build index container on restricted environments, to fix the following error from build index container:

Error from server (Forbidden): error when creating "STDIN": pods "buildindex" is forbidden: violates PodSecurity "restricted:v1.24": privileged (container "priv" must not set securityContext.privileged=true), allowPrivilegeEscalation != false (container "priv" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "priv" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "priv" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "priv" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")