### PR TITLE
E2E: Override the external frr image

### DIFF
--- a/openshift-ci/run_e2e.sh
+++ b/openshift-ci/run_e2e.sh
@@ -79,4 +79,4 @@ FOCUS="\"L2.*should work for ExternalTrafficPolicy=Cluster\"\|\"BGP.*A service o
 inv e2etest --kubeconfig=$(readlink -f ../../../ocp/ostest/auth/kubeconfig) \
 	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
 	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--focus="${FOCUS}" --use-operator
+	--focus="${FOCUS}" --use-operator --external_frr_image=quay.io/openshift/origin-metallb-frr:4.13


### PR DESCRIPTION
This commit adds the --external_frr_image flag
into metallb `inv e2etest` command, thus
overrides the external containers` frr image.

This is required as we're facing e2e test failures with  FRR BFD + echo test case, and to prevent
it we want to align the FRR version between
the speakers and the external container.
