### PR TITLE
OCPBUGS-14277: 4.11 backport: read memberlist secret from file instead of env var

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -95,6 +95,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.logLevel | string | `"info"` | Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
 | speaker.memberlist.enabled | bool | `true` |  |
 | speaker.memberlist.mlBindPort | int | `7946` |  |
+| speaker.memberlist.mlSecretKeyPath | string | `"/etc/ml_secret_key"` |  |
 | speaker.nodeSelector | object | `{}` |  |
 | speaker.podAnnotations | object | `{}` |  |
 | speaker.priorityClassName | string | `""` |  |

--- a/charts/metallb/policy/speaker.rego
+++ b/charts/metallb/policy/speaker.rego
@@ -11,15 +11,8 @@ deny[msg] {
 # validate METALLB_ML_SECRET_KEY (memberlist)
 deny[msg] {
 	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY"
-	msg = "speaker env does not contain METALLB_ML_SECRET_KEY at env[5]"
-}
-
-deny[msg] {
-	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.name == "RELEASE-NAME-metallb-memberlist"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.key == "secretkey"
-	msg = "speaker env METALLB_ML_SECRET_KEY secretKeyRef does not equal expected value"
+	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY_PATH"
+	msg = "speaker env does not contain METALLB_ML_SECRET_KEY_PATH at env[5]"
 }
 
 # validate node selector includes builtin when custom ones are provided

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -143,6 +143,13 @@ spec:
       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
+      volumes:
+      {{- if .Values.speaker.memberlist.enabled }}
+        - name: memberlist
+          secret:
+            secretName: {{ include "metallb.secretName" . }}
+            defaultMode: 420
+      {{- end }}
       {{- if .Values.speaker.frr.enabled }}
       volumes:
         - name: frr-sockets
@@ -217,11 +224,8 @@ spec:
           value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
         - name: METALLB_ML_BIND_PORT
           value: "{{ .Values.speaker.memberlist.mlBindPort }}"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "metallb.secretName" . }}
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: "{{ .Values.speaker.memberlist.mlSecretKeyPath }}"
         {{- end }}
         {{- if .Values.speaker.frr.enabled }}
         - name: FRR_CONFIG_FILE
@@ -276,11 +280,17 @@ spec:
             - ALL
             add:
             - NET_RAW
-        {{- if .Values.speaker.frr.enabled }}
+        {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled }}
         volumeMounts:
+          {{- if .Values.speaker.memberlist.enabled }}
+          - name: memberlist 
+            mountPath: {{ .Values.speaker.memberlist.mlSecretKeyPath }}
+          {{- end }}
+          {{- if .Values.speaker.frr.enabled }}
           - name: reloader
             mountPath: /etc/frr_reloader
-         {{- end }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -287,6 +287,9 @@
                 },
                 "mlBindPort": {
                   "type": "integer"
+                },
+                "mlSecretKeyPath": {
+                  "type": "string"
                 }
               }
             },

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -174,6 +174,7 @@ speaker:
   memberlist:
     enabled: true
     mlBindPort: 7946
+    mlSecretKeyPath: "/etc/ml_secret_key"
   image:
     repository: quay.io/metallb/speaker
     tag:

--- a/config/controllers/speaker.yaml
+++ b/config/controllers/speaker.yaml
@@ -43,11 +43,8 @@ spec:
         #  value: "7946"
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: memberlist
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: "/etc/ml_secret_key"
         image: quay.io/metallb/speaker:main
         name: speaker
         ports:
@@ -84,6 +81,10 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -96,3 +97,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists 
+      volumes:
+      - name: memberlist 
+        secret: 
+          secretName: memberlist
+          defaultMode: 420

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -1824,11 +1824,8 @@ spec:
               fieldPath: status.podIP
         - name: METALLB_ML_LABELS
           value: app=metallb,component=speaker
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secretkey
-              name: memberlist
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: /etc/ml_secret_key
         image: quay.io/metallb/speaker:main
         livenessProbe:
           failureThreshold: 3
@@ -1868,6 +1865,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/frr_reloader
           name: reloader
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
       hostNetwork: true
       initContainers:
       - command:
@@ -1926,6 +1926,10 @@ spec:
         name: reloader
       - emptyDir: {}
         name: metrics
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -1663,11 +1663,8 @@ spec:
               fieldPath: status.podIP
         - name: METALLB_ML_LABELS
           value: app=metallb,component=speaker
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              key: secretkey
-              name: memberlist
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: /etc/ml_secret_key
         image: quay.io/metallb/speaker:main
         livenessProbe:
           failureThreshold: 3
@@ -1704,6 +1701,10 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: linux
@@ -1716,6 +1717,11 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
+      volumes:
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -52,8 +52,9 @@ import (
 )
 
 const (
-	caName         = "cert"
-	caOrganization = "metallb"
+	caName          = "cert"
+	caOrganization  = "metallb"
+	MLSecretKeyName = "secretkey"
 )
 
 var (
@@ -430,7 +431,7 @@ func (c *Client) CreateMlSecret(namespace, controllerDeploymentName, secretName 
 					UID:  d.UID,
 				}},
 			},
-			Data: map[string][]byte{"secretkey": secretB64},
+			Data: map[string][]byte{MLSecretKeyName: secretB64},
 		},
 		metav1.CreateOptions{})
 	if err == nil {

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/go-kit/log"
@@ -67,7 +68,7 @@ func main() {
 		mlBindAddr        = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
 		mlBindPort        = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
 		mlLabels          = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
-		mlSecret          = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
+		mlSecretKeyPath   = flag.String("ml-secret-key-path", os.Getenv("METALLB_ML_SECRET_KEY_PATH"), "Path to where the MembeList's secret key is mounted")
 		myNode            = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
 		port              = flag.Int("port", 7472, "HTTP listening port")
 		logLevel          = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
@@ -117,7 +118,18 @@ func main() {
 	}()
 	defer level.Info(logger).Log("op", "shutdown", "msg", "done")
 
-	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, *mlSecret, *namespace, *mlLabels, stopCh)
+	var mlSecret string
+
+	if *mlSecretKeyPath != "" {
+		mlSecretBytes, err := os.ReadFile(filepath.Join(*mlSecretKeyPath, k8s.MLSecretKeyName))
+		if err != nil {
+			level.Error(logger).Log("op", "startup", "error", err, "msg", "failed to read memberlist secret key file")
+			os.Exit(1)
+		}
+		mlSecret = string(mlSecretBytes)
+	}
+
+	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, mlSecret, *namespace, *mlLabels, stopCh)
 	if err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is a cherry-pick from 4.12.
https://github.com/openshift/metallb/pull/107

Makes the memberlist secret env var hold the path to the secret instead the secret itself.
and makes the speaker consume the secret by reading from that path.