### PR TITLE
OCPBUGS-14411: Add support for BGP large communities

### DIFF
--- a/api/v1beta1/bgpadvertisement_types.go
+++ b/api/v1beta1/bgpadvertisement_types.go
@@ -41,8 +41,9 @@ type BGPAdvertisementSpec struct {
 	// +optional
 	LocalPref uint32 `json:"localPref,omitempty"`
 
-	// The BGP communities to be associated with the announcement. Each item can be a
-	// community of the form 1234:1234 or the name of an alias defined in the Community CRD.
+	// The BGP communities to be associated with the announcement. Each item can be a standard community of the
+	// form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+	// Community CRD.
 	// +optional
 	Communities []string `json:"communities,omitempty"`
 

--- a/api/v1beta1/community_types.go
+++ b/api/v1beta1/community_types.go
@@ -23,7 +23,8 @@ import (
 type CommunityAlias struct {
 	// The name of the alias for the community.
 	Name string `json:"name,omitempty"`
-	// The BGP community value corresponding to the given name.
+	// The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+	// or a large community of the form large:1234:1234:1234.
 	Value string `json:"value,omitempty"`
 }
 

--- a/config/crd/bases/metallb.io_bgpadvertisements.yaml
+++ b/config/crd/bases/metallb.io_bgpadvertisements.yaml
@@ -67,8 +67,9 @@ spec:
                 type: integer
               communities:
                 description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                  Each item can be a standard community of the form 1234:1234, a large
+                  community of the form large:1234:1234:1234 or the name of an alias
+                  defined in the Community CRD.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/metallb.io_communities.yaml
+++ b/config/crd/bases/metallb.io_communities.yaml
@@ -44,7 +44,8 @@ spec:
                       type: string
                     value:
                       description: The BGP community value corresponding to the given
-                        name.
+                        name. Can be a standard community of the form 1234:1234 or
+                        a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -388,8 +388,9 @@ spec:
                 type: integer
               communities:
                 description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                  Each item can be a standard community of the form 1234:1234, a large
+                  community of the form large:1234:1234:1234 or the name of an alias
+                  defined in the Community CRD.
                 items:
                   type: string
                 type: array
@@ -881,7 +882,8 @@ spec:
                       type: string
                     value:
                       description: The BGP community value corresponding to the given
-                        name.
+                        name. Can be a standard community of the form 1234:1234 or
+                        a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -388,8 +388,9 @@ spec:
                 type: integer
               communities:
                 description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                  Each item can be a standard community of the form 1234:1234, a large
+                  community of the form large:1234:1234:1234 or the name of an alias
+                  defined in the Community CRD.
                 items:
                   type: string
                 type: array
@@ -881,7 +882,8 @@ spec:
                       type: string
                     value:
                       description: The BGP community value corresponding to the given
-                        name.
+                        name. Can be a standard community of the form 1234:1234 or
+                        a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array

--- a/config/manifests/metallb-native-prometheus.yaml
+++ b/config/manifests/metallb-native-prometheus.yaml
@@ -388,8 +388,9 @@ spec:
                 type: integer
               communities:
                 description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                  Each item can be a standard community of the form 1234:1234, a large
+                  community of the form large:1234:1234:1234 or the name of an alias
+                  defined in the Community CRD.
                 items:
                   type: string
                 type: array
@@ -881,7 +882,8 @@ spec:
                       type: string
                     value:
                       description: The BGP community value corresponding to the given
-                        name.
+                        name. Can be a standard community of the form 1234:1234 or
+                        a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array

--- a/config/manifests/metallb-native.yaml
+++ b/config/manifests/metallb-native.yaml
@@ -388,8 +388,9 @@ spec:
                 type: integer
               communities:
                 description: The BGP communities to be associated with the announcement.
-                  Each item can be a community of the form 1234:1234 or the name of
-                  an alias defined in the Community CRD.
+                  Each item can be a standard community of the form 1234:1234, a large
+                  community of the form large:1234:1234:1234 or the name of an alias
+                  defined in the Community CRD.
                 items:
                   type: string
                 type: array
@@ -881,7 +882,8 @@ spec:
                       type: string
                     value:
                       description: The BGP community value corresponding to the given
-                        name.
+                        name. Can be a standard community of the form 1234:1234 or
+                        a large community of the form large:1234:1234:1234.
                       type: string
                   type: object
                 type: array

--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -807,6 +807,20 @@ var _ = ginkgo.Describe("BGP", func() {
 				false,
 				ipfamily.IPv4,
 				[]metallbv1beta1.Community{}),
+			ginkgo.Entry("FRR - IPV4 - large community and localpref",
+				"192.168.10.0/24",
+				"192.168.16.0/24",
+				metallbv1beta1.BGPAdvertisement{
+					ObjectMeta: metav1.ObjectMeta{Name: "advertisement"},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						Communities:    []string{"large:123:456:7890"},
+						LocalPref:      50,
+						IPAddressPools: []string{"bgp-with-advertisement"},
+					},
+				},
+				false,
+				ipfamily.IPv4,
+				[]metallbv1beta1.Community{}),
 			ginkgo.Entry("IPV4 - localpref",
 				"192.168.10.0/24",
 				"192.168.16.0/24",
@@ -972,8 +986,21 @@ var _ = ginkgo.Describe("BGP", func() {
 				},
 				false,
 				ipfamily.IPv6,
+				[]metallbv1beta1.Community{}),
+			ginkgo.Entry("FRR - IPV6 - large community and localpref",
+				"fc00:f853:0ccd:e799::0-fc00:f853:0ccd:e799::18",
+				"fc00:f853:0ccd:e799::19-fc00:f853:0ccd:e799::26",
+				metallbv1beta1.BGPAdvertisement{
+					ObjectMeta: metav1.ObjectMeta{Name: "advertisement"},
+					Spec: metallbv1beta1.BGPAdvertisementSpec{
+						Communities:    []string{"large:123:456:7890"},
+						LocalPref:      50,
+						IPAddressPools: []string{"bgp-with-advertisement"},
+					},
+				},
+				false,
+				ipfamily.IPv6,
 				[]metallbv1beta1.Community{}))
-
 	})
 
 	ginkgo.Context("MetalLB FRR rejects", func() {

--- a/e2etest/webhookstests/webhooks.go
+++ b/e2etest/webhookstests/webhooks.go
@@ -224,7 +224,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 	})
 
 	ginkgo.Context("For Community", func() {
-		ginkgo.It("Should reject a new invalid Community", func() {
+		ginkgo.DescribeTable("reject a new invalid Community", func(community, expectedError string) {
 			ginkgo.By("Creating invalid Community")
 			resources := metallbconfig.ClusterResources{
 				Communities: []metallbv1beta1.Community{
@@ -236,7 +236,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 							Communities: []metallbv1beta1.CommunityAlias{
 								{
 									Name:  "INVALID_COMMUNITY",
-									Value: "99999999:1",
+									Value: community,
 								},
 							},
 						},
@@ -245,10 +245,12 @@ var _ = ginkgo.Describe("Webhooks", func() {
 			}
 			err := ConfigUpdater.Update(resources)
 			framework.ExpectError(err)
-			Expect(err.Error()).To(ContainSubstring("invalid first section of community"))
-		})
+			Expect(err.Error()).To(ContainSubstring(expectedError))
+		},
+			ginkgo.Entry("in legacy format", "99999999:1", "invalid community value: invalid section"),
+			ginkgo.Entry("in large format", "lar:123:9999:123", "expected community to be of format large"))
 
-		ginkgo.It("Should reject an update to an invalid Community", func() {
+		ginkgo.DescribeTable("reject an update to an invalid Community", func(community, expectedError string) {
 			ginkgo.By("Creating Community")
 			resources := metallbconfig.ClusterResources{
 				Communities: []metallbv1beta1.Community{
@@ -267,16 +269,18 @@ var _ = ginkgo.Describe("Webhooks", func() {
 				Communities: []metallbv1beta1.CommunityAlias{
 					{
 						Name:  "INVALID_COMMUNITY",
-						Value: "99999999:1",
+						Value: community,
 					},
 				},
 			}
 			err = ConfigUpdater.Update(resources)
 			framework.ExpectError(err)
-			Expect(err.Error()).To(ContainSubstring("invalid first section of community"))
-		})
+			Expect(err.Error()).To(ContainSubstring(expectedError))
+		},
+			ginkgo.Entry("in legacy format", "99999999:1", "invalid community value: invalid section"),
+			ginkgo.Entry("in large format", "lar:123:9999:123", "expected community to be of format large"))
 
-		ginkgo.It("Should reject Community duplications", func() {
+		ginkgo.DescribeTable("reject Community duplications", func(community string) {
 			ginkgo.By("Creating duplicates in the same Community")
 			resources := metallbconfig.ClusterResources{
 				Communities: []metallbv1beta1.Community{
@@ -288,11 +292,11 @@ var _ = ginkgo.Describe("Webhooks", func() {
 							Communities: []metallbv1beta1.CommunityAlias{
 								{
 									Name:  "DUP_COMMUNITY",
-									Value: "1111:2222",
+									Value: community,
 								},
 								{
 									Name:  "DUP_COMMUNITY",
-									Value: "1111:2222",
+									Value: community,
 								},
 							},
 						},
@@ -314,7 +318,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 							Communities: []metallbv1beta1.CommunityAlias{
 								{
 									Name:  "DUP_COMMUNITY",
-									Value: "1111:2222",
+									Value: community,
 								},
 							},
 						},
@@ -327,7 +331,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 							Communities: []metallbv1beta1.CommunityAlias{
 								{
 									Name:  "DUP_COMMUNITY",
-									Value: "1111:2222",
+									Value: community,
 								},
 							},
 						},
@@ -337,7 +341,9 @@ var _ = ginkgo.Describe("Webhooks", func() {
 			err = ConfigUpdater.Update(resources)
 			framework.ExpectError(err)
 			Expect(err.Error()).To(ContainSubstring("duplicate definition of community"))
-		})
+		},
+			ginkgo.Entry("in legacy format", "1111:2222"),
+			ginkgo.Entry("FRR - in large format", "large:123:9999:123"))
 	})
 
 	ginkgo.Context("For BFDProfile", func() {

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"go.universe.tf/metallb/internal/bgp/community"
 	"go.universe.tf/metallb/internal/config"
 )
 
@@ -20,7 +21,7 @@ type Advertisement struct {
 	// peers (i.e. where the peer ASN matches the local ASN).
 	LocalPref uint32
 	// BGP communities to attach to the path.
-	Communities []uint32
+	Communities []community.BGPCommunity
 	// Used to declare the intent of announcing IPs
 	// only to the BGPPeers in this list.
 	Peers []string

--- a/internal/bgp/community/community.go
+++ b/internal/bgp/community/community.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package community
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrInvalidCommunityValue  = errors.New("invalid community value")
+	ErrInvalidCommunityFormat = errors.New("invalid community format")
+)
+
+// largeBGPCommunityMarker is the prefix that shall be used to indicate that a given community value is of type large
+// community. If and when extended BGP communities will be supported, the largeBGPCommunityMarker allows us to
+// distinguish between extended and large communities.
+const largeBGPCommunityMarker = "large"
+
+// BGPCommunity represents a BGP community.
+type BGPCommunity interface {
+	LessThan(BGPCommunity) bool
+	String() string
+}
+
+// New parses the provided string and returns a newly created BGPCommunity object.
+// Strings are parsed according to Juniper style  syntax (https://www.juniper.net/documentation/us/en/software/\
+// junos/routing-policy/bgp/topics/concept/policy-bgp-communities-extended-communities-match-conditions-overview.html
+// Legacy communities are of format "<AS number>:<community value>".
+// Extended communities (support of which is yet to be implemented) are of format "<type>:<administrator>:<assigned-number>".
+// Large communities are of format large:<global administrator>:<localdata part 1>:<localdata part 2>.
+func New(c string) (BGPCommunity, error) {
+	var bgpCommunity BGPCommunity
+
+	fs := strings.Split(c, ":")
+	switch l := len(fs); l {
+	case 2:
+		var fields [2]uint16
+		for i := 0; i < 2; i++ {
+			b, err := strconv.ParseUint(fs[i], 10, 16)
+			if err != nil {
+				return bgpCommunity, fmt.Errorf("%w: invalid section %q of community %q, err: %q",
+					ErrInvalidCommunityValue, fs[i], c, err)
+			}
+			fields[i] = uint16(b)
+		}
+		return BGPCommunityLegacy{
+			upperVal: fields[0],
+			lowerVal: fields[1],
+		}, nil
+	case 4:
+		if fs[0] != largeBGPCommunityMarker {
+			return bgpCommunity, fmt.Errorf("%w: invalid marker for large community, expected community to be of "+
+				"format %s:<uint32>:<uint32>:<uint32> but got %q instead",
+				ErrInvalidCommunityValue, largeBGPCommunityMarker, c)
+		}
+		var fields [3]uint32
+		for i := 1; i < 4; i++ {
+			b, err := strconv.ParseUint(fs[i], 10, 32)
+			if err != nil {
+				return bgpCommunity, fmt.Errorf("%w: invalid section %q of community %q, err: %q",
+					ErrInvalidCommunityValue, fs[i], c, err)
+			}
+			fields[i-1] = uint32(b)
+		}
+		return BGPCommunityLarge{
+			globalAdministrator: fields[0],
+			localDataPart1:      fields[1],
+			localDataPart2:      fields[2],
+		}, nil
+	}
+
+	return bgpCommunity, fmt.Errorf("%w: %s", ErrInvalidCommunityFormat, c)
+}
+
+// BGPCommunityLegacy holds the internal representation of a BGP legacy community.
+type BGPCommunityLegacy struct {
+	upperVal uint16
+	lowerVal uint16
+}
+
+// LessThan makes 2 different BGPCommunity objects comparable. For the sake of comparison, legacy communities are
+// considered to be large communities in format <legacy community>:0:0 and thus can be compared with large communities.
+func (b BGPCommunityLegacy) LessThan(c BGPCommunity) bool {
+	return lessThan(b, c)
+}
+
+// String returns the string representation of this community. Legacy communities will be printed in new-format,
+// "<AS number>:<community value>".
+func (b BGPCommunityLegacy) String() string {
+	return fmt.Sprintf("%d:%d", b.upperVal, b.lowerVal)
+}
+
+// ToUint32 returns the uint32 representation of this legacy community.
+func (b BGPCommunityLegacy) ToUint32() uint32 {
+	return (uint32(b.upperVal) << 16) + uint32(b.lowerVal)
+}
+
+// BGPCommunity holds the internal representation of a large BGP community.
+type BGPCommunityLarge struct {
+	globalAdministrator uint32
+	localDataPart1      uint32
+	localDataPart2      uint32
+}
+
+// LessThan makes 2 different BGPCommunity objects comparable. For the sake of comparison, legacy communities are
+// considered to be large communities in format <legacy community>:0:0 and thus can be compared with large communities.
+func (b BGPCommunityLarge) LessThan(c BGPCommunity) bool {
+	return lessThan(b, c)
+}
+
+// String returns the string representation of this community. Large communities will be printed as
+// ("<global administrator>:<localdata part 1>:<localdata part 2>").
+func (b BGPCommunityLarge) String() string {
+	return fmt.Sprintf("%d:%d:%d", b.globalAdministrator, b.localDataPart1, b.localDataPart2)
+}
+
+// IsLegacy returns true if this is a Legacy community.
+func IsLegacy(c BGPCommunity) bool {
+	_, ok := c.(BGPCommunityLegacy)
+	return ok
+}
+
+// IsLarge returns true if this is a Legacy community.
+func IsLarge(c BGPCommunity) bool {
+	_, ok := c.(BGPCommunityLarge)
+	return ok
+}
+
+// lessThan is a helper function that compares two communities regardless of their type.
+func lessThan(b BGPCommunity, c BGPCommunity) bool {
+	var bl BGPCommunityLarge
+	var cl BGPCommunityLarge
+	switch v := b.(type) {
+	case BGPCommunityLegacy:
+		bl = BGPCommunityLarge{
+			globalAdministrator: v.ToUint32(),
+			localDataPart1:      0,
+			localDataPart2:      0,
+		}
+	case BGPCommunityLarge:
+		bl = v
+	}
+
+	switch v := c.(type) {
+	case BGPCommunityLegacy:
+		cl = BGPCommunityLarge{
+			globalAdministrator: v.ToUint32(),
+			localDataPart1:      0,
+			localDataPart2:      0,
+		}
+	case BGPCommunityLarge:
+		cl = v
+	}
+	return bl.globalAdministrator < cl.globalAdministrator ||
+		(bl.globalAdministrator == cl.globalAdministrator && (bl.localDataPart1 < cl.localDataPart1 ||
+			(bl.localDataPart1 == cl.localDataPart1 && bl.localDataPart2 < cl.localDataPart2)))
+}

--- a/internal/bgp/community/community_test.go
+++ b/internal/bgp/community/community_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package community
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewBGPCommunity(t *testing.T) {
+	tcs := map[string]struct {
+		input       string
+		output      BGPCommunity
+		errorString string
+	}{
+		"valid legacy community in new-format": {
+			input:  "12345:12345",
+			output: BGPCommunityLegacy{upperVal: 12345, lowerVal: 12345},
+		},
+		"legacy community in old-format not supported": {
+			input:       "12345",
+			errorString: "invalid community format: 12345",
+		},
+		"valid large community": {
+			input: "large:12345:12345:12345",
+			output: BGPCommunityLarge{
+				globalAdministrator: 12345,
+				localDataPart1:      12345,
+				localDataPart2:      12345,
+			},
+		},
+		"invalid large community 1": {
+			input:       "larg:12345:12345:12345",
+			errorString: "invalid community value: invalid marker for large community",
+		},
+		"invalid large community 2": {
+			input:       "large:12345:wrong:12345",
+			errorString: "invalid community value: invalid section",
+		},
+		"invalid extended community not yet implemented": {
+			input:       "12345:12345:12345",
+			errorString: "invalid community format: 12345:12345:12345",
+		},
+	}
+	for d, tc := range tcs {
+		c, err := New(tc.input)
+		if tc.errorString != "" {
+			if err == nil {
+				t.Fatalf("%s(%s): Expected to see an error but got <nil> instead", t.Name(), d)
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("%s(%s): Expected returned error to contain '%s', but got %q instead",
+					t.Name(), d, tc.errorString, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s(%s): Expected to see no error, but got %q instead", t.Name(), d, err)
+		}
+		if c != tc.output {
+			t.Fatalf("%s(%s): Parsed community and expected community do not match.\n"+
+				"Expected:\n%v\nGot:\n%v\n", t.Name(), d, tc.output, c)
+		}
+	}
+}
+
+func TestBGPCommunityLessThan(t *testing.T) {
+	tcs := map[string]struct {
+		left            string
+		right           string
+		expectedOutcome bool
+	}{
+		"compares legacy communities":           {left: "0:1234", right: "0:2345", expectedOutcome: true},
+		"compares large communities 1":          {left: "large:1234:0:0", right: "large:1234:0:1", expectedOutcome: true},
+		"compares large communities 2":          {left: "large:1235:0:0", right: "large:1234:1:0", expectedOutcome: false},
+		"compares legacy and large communities": {left: "0:1234", right: "large:123:456:789", expectedOutcome: false},
+	}
+	for d, tc := range tcs {
+		leftCommunity, _ := New(tc.left)
+		rightCommunity, _ := New(tc.right)
+		if leftCommunity.LessThan(rightCommunity) != tc.expectedOutcome {
+			t.Fatalf("%s(%s): did not get expected outcome %t when comparing communities %q and %q",
+				t.Name(), d, tc.expectedOutcome, tc.left, tc.right)
+		}
+	}
+}
+
+func TestBGPCommunityString(t *testing.T) {
+	tcs := map[string]struct {
+		input  string
+		output string
+	}{
+		"legacy community": {input: "0:1234", output: "0:1234"},
+		"large community":  {input: "large:1:2:3", output: "1:2:3"},
+	}
+	for d, tc := range tcs {
+		community, _ := New(tc.input)
+		if community.String() != tc.output {
+			t.Fatalf("%s(%s): did not get expected output string %q, got: %q", t.Name(), d, tc.output, community)
+		}
+	}
+}

--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -88,10 +88,11 @@ func (n *neighborConfig) ID() string {
 }
 
 type advertisementConfig struct {
-	IPFamily    ipfamily.Family
-	Prefix      string
-	Communities []string
-	LocalPref   uint32
+	IPFamily         ipfamily.Family
+	Prefix           string
+	Communities      []string
+	LargeCommunities []string
+	LocalPref        uint32
 }
 
 // routerName() defines the format of the key of the "Routers" map in the
@@ -132,6 +133,9 @@ func templateConfig(data interface{}) (string, error) {
 			},
 			"communityPrefixList": func(neighbor *neighborConfig, community string) string {
 				return fmt.Sprintf("%s-%s-%s-community-prefixes", neighbor.ID(), community, neighbor.IPFamily)
+			},
+			"largeCommunityPrefixList": func(neighbor *neighborConfig, community string) string {
+				return fmt.Sprintf("%s-large:%s-%s-community-prefixes", neighbor.ID(), community, neighbor.IPFamily)
 			},
 			"allowedPrefixList": func(neighbor *neighborConfig) string {
 				return fmt.Sprintf("%s-pl-%s", neighbor.ID(), neighbor.IPFamily)

--- a/internal/bgp/frr/frr_vrf_test.go
+++ b/internal/bgp/frr/frr_vrf_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"go.universe.tf/metallb/internal/bgp"
-	"go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/bgp/community"
 	"go.universe.tf/metallb/internal/logging"
 )
 
@@ -236,11 +236,11 @@ func TestSingleAdvertisementVRF(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
-	communities = append(communities, community)
-	community, _ = config.ParseCommunity("3333:4444")
-	communities = append(communities, community)
+	communities := []community.BGPCommunity{}
+	community1, _ := community.New("1111:2222")
+	communities = append(communities, community1)
+	community2, _ := community.New("3333:4444")
+	communities = append(communities, community2)
 	adv := &bgp.Advertisement{
 		Prefix:      prefix,
 		Communities: communities,
@@ -341,11 +341,11 @@ func TestSingleAdvertisementWithPeerSelectorVRF(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
-	communities = append(communities, community)
-	community, _ = config.ParseCommunity("3333:4444")
-	communities = append(communities, community)
+	communities := []community.BGPCommunity{}
+	community1, _ := community.New("1111:2222")
+	communities = append(communities, community1)
+	community2, _ := community.New("3333:4444")
+	communities = append(communities, community2)
 	adv := &bgp.Advertisement{
 		Prefix:      prefix,
 		Communities: communities,
@@ -390,8 +390,8 @@ func TestTwoAdvertisementsVRF(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
+	communities := []community.BGPCommunity{}
+	community, _ := community.New("1111:2222")
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,
@@ -462,8 +462,8 @@ func TestTwoAdvertisementsTwoSessionsOneVRF(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
+	communities := []community.BGPCommunity{}
+	community, _ := community.New("1111:2222")
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,
@@ -541,8 +541,8 @@ func TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
+	communities := []community.BGPCommunity{}
+	community, _ := community.New("1111:2222")
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,
@@ -622,8 +622,8 @@ func TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector(t *testing.T) {
 		IP:   net.ParseIP("172.16.1.10"),
 		Mask: classCMask,
 	}
-	communities := []uint32{}
-	community, _ := config.ParseCommunity("1111:2222")
+	communities := []community.BGPCommunity{}
+	community, _ := community.New("1111:2222")
 	communities = append(communities, community)
 	adv1 := &bgp.Advertisement{
 		Prefix:      prefix1,

--- a/internal/bgp/frr/templates/filters.tmpl
+++ b/internal/bgp/frr/templates/filters.tmpl
@@ -14,6 +14,14 @@ route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   on-match next
 {{- end -}}
 
+{{- define "largecommunityfilter" -}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{largeCommunityPrefixList .neighbor .largecommunity}} permit {{.advertisement.Prefix}}
+route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
+  match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{largeCommunityPrefixList .neighbor .largecommunity}}
+  set large-community {{.largecommunity}} additive
+  on-match next
+{{- end -}}
+
 {{- /* The prefixes are per router in FRR, but MetalLB api allows to associate a given BGPAdvertisement to a service IP,
      and a given advertisement contains both the properties of the announcement (i.e. community) and the list of peers
      we may want to advertise to. Because of this, for each neighbor we must opt-in and allow the advertisement, and
@@ -30,6 +38,9 @@ route-map {{.neighbor.ID}}-in deny 20
 {{/* Advertisements for which we must enable the community property */}}
 {{- range $c := $a.Communities }}
 {{template "communityfilter" dict "advertisement" $a "neighbor" $.neighbor "community" $c}}
+{{- end }}
+{{- range $lc := $a.LargeCommunities }}
+{{template "largecommunityfilter" dict "advertisement" $a "neighbor" $.neighbor "largecommunity" $lc}}
 {{- end }}
 {{/* this advertisement is allowed to the specific neighbor  */}}
 {{frrIPFamily $a.IPFamily}} prefix-list {{allowedPrefixList $.neighbor}} permit {{$a.Prefix}}

--- a/internal/bgp/frr/testdata/TestLargeCommunities.golden
+++ b/internal/bgp/frr/testdata/TestLargeCommunities.golden
@@ -1,0 +1,66 @@
+log file /etc/frr/frr.log 
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-300-ipv4-localpref-prefixes
+  set local-preference 300
+  on-match next
+ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-out permit 2
+  match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
+  set community 3333:4444 additive
+  on-match next
+ip prefix-list 10.2.2.254-large:1111:2222:3333-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-out permit 3
+  match ip address prefix-list 10.2.2.254-large:1111:2222:3333-ipv4-community-prefixes
+  set large-community 1111:2222:3333 additive
+  on-match next
+ip prefix-list 10.2.2.254-large:2222:3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+route-map 10.2.2.254-out permit 4
+  match ip address prefix-list 10.2.2.254-large:2222:3333:4444-ipv4-community-prefixes
+  set large-community 2222:3333:4444 additive
+  on-match next
+
+ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+route-map 10.2.2.254-out permit 5
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 6
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+
+ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"go.universe.tf/metallb/api/v1beta1"
 	"go.universe.tf/metallb/api/v1beta2"
+	"go.universe.tf/metallb/internal/bgp/community"
 	"go.universe.tf/metallb/internal/pointer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -255,9 +256,12 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities: map[uint32]bool{
-									0xfc0004d2: true,
-								},
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("64512:1234")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
 								Nodes: map[string]bool{},
 								Peers: []string{"peer1"},
 							},
@@ -265,7 +269,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv2",
 								AggregationLength:   24,
 								AggregationLengthV6: 64,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -283,7 +287,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv3",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -1019,7 +1023,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv3",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -1061,7 +1065,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv3",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -1248,14 +1252,14 @@ func TestParse(t *testing.T) {
 								AggregationLength:   24,
 								AggregationLengthV6: 120,
 								LocalPref:           100,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node1": true, "node2": true},
 							},
 							{
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           200,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node1": true, "node2": true},
 							},
 						},
@@ -1328,14 +1332,14 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node1": true},
 							},
 							{
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           200,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node2": true},
 							},
 						},
@@ -1399,7 +1403,7 @@ func TestParse(t *testing.T) {
 								AggregationLengthV6: 128,
 								LocalPref:           100,
 								Peers:               []string{"peer1"},
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node1": true, "node2": true},
 							},
 							{
@@ -1407,7 +1411,7 @@ func TestParse(t *testing.T) {
 								AggregationLengthV6: 128,
 								LocalPref:           200,
 								Peers:               []string{"peer2"},
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"node1": true, "node2": true},
 							},
 						},
@@ -1462,7 +1466,7 @@ func TestParse(t *testing.T) {
 							{
 								AggregationLength:   26,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -1872,7 +1876,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv3",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -2116,7 +2120,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv3",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -2297,7 +2301,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -2423,9 +2427,12 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities: map[uint32]bool{
-									0x04D20929: true,
-								},
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("1234:2345")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
 								Nodes: map[string]bool{},
 							},
 						},
@@ -2438,9 +2445,12 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities: map[uint32]bool{
-									0x04D20929: true,
-								},
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("1234:2345")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
 								Nodes: map[string]bool{},
 							},
 						},
@@ -2509,9 +2519,213 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities: map[uint32]bool{
-									0xfc0004d2: true,
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("64512:1234")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
+								Nodes: map[string]bool{},
+							},
+						},
+					},
+				}},
+				BFDProfiles: map[string]*BFDProfile{},
+				Peers:       map[string]*Peer{},
+			},
+		},
+		{
+			desc: "config IPAddressPool with large communities CR",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "peer1",
+						},
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:        42,
+							ASN:          142,
+							Address:      "1.2.3.4",
+							Port:         1179,
+							HoldTime:     metav1.Duration{Duration: 180 * time.Second},
+							RouterID:     "10.20.30.40",
+							SrcAddress:   "10.20.30.40",
+							EBGPMultiHop: true,
+							VRFName:      "foo",
+						},
+					},
+				},
+				Pools: []v1beta1.IPAddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pool1",
+						},
+						Spec: v1beta1.IPAddressPoolSpec{
+							Addresses: []string{
+								"10.20.0.0/16",
+								"10.50.0.0/24",
+							},
+							AvoidBuggyIPs: true,
+							AutoAssign:    pointer.BoolPtr(false),
+						},
+					},
+				},
+				BGPAdvs: []v1beta1.BGPAdvertisement{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv1",
+						},
+						Spec: v1beta1.BGPAdvertisementSpec{
+							AggregationLength: pointer.Int32Ptr(32),
+							LocalPref:         uint32(100),
+							Communities:       []string{"bar"},
+							IPAddressPools:    []string{"pool1"},
+							Peers:             []string{"peer1"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv2",
+						},
+						Spec: v1beta1.BGPAdvertisementSpec{
+							AggregationLength:   pointer.Int32Ptr(24),
+							AggregationLengthV6: pointer.Int32Ptr(64),
+							IPAddressPools:      []string{"pool1"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "adv3",
+						},
+						Spec: v1beta1.BGPAdvertisementSpec{
+							IPAddressPools: []string{"pool2"},
+						},
+					},
+				},
+				Communities: []v1beta1.Community{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "community",
+						},
+						Spec: v1beta1.CommunitySpec{
+							Communities: []v1beta1.CommunityAlias{
+								{
+									Name:  "bar",
+									Value: "large:123:64512:1234",
 								},
+							},
+						},
+					},
+				},
+			},
+			want: &Config{
+				Peers: map[string]*Peer{
+					"peer1": {
+						Name:          "peer1",
+						MyASN:         42,
+						ASN:           142,
+						Addr:          net.ParseIP("1.2.3.4"),
+						SrcAddr:       net.ParseIP("10.20.30.40"),
+						Port:          1179,
+						HoldTime:      180 * time.Second,
+						KeepaliveTime: 60 * time.Second,
+						RouterID:      net.ParseIP("10.20.30.40"),
+						NodeSelectors: []labels.Selector{labels.Everything()},
+						EBGPMultiHop:  true,
+						VRF:           "foo",
+					},
+				},
+				Pools: &Pools{ByName: map[string]*Pool{
+					"pool1": {
+						Name:          "pool1",
+						CIDR:          []*net.IPNet{ipnet("10.20.0.0/16"), ipnet("10.50.0.0/24")},
+						AvoidBuggyIPs: true,
+						AutoAssign:    false,
+						BGPAdvertisements: []*BGPAdvertisement{
+							{
+								Name:                "adv1",
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								LocalPref:           100,
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("large:123:64512:1234")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
+								Nodes: map[string]bool{},
+								Peers: []string{"peer1"},
+							},
+							{
+								Name:                "adv2",
+								AggregationLength:   24,
+								AggregationLengthV6: 64,
+								Communities:         map[community.BGPCommunity]bool{},
+								Nodes:               map[string]bool{},
+							},
+						},
+					},
+				}},
+				BFDProfiles: map[string]*BFDProfile{},
+			},
+		},
+		{
+			desc: "config legacy pool with BGP Communities CR and large communities",
+			crs: ClusterResources{
+				LegacyAddressPools: []v1beta1.AddressPool{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "legacybgppool1",
+						},
+						Spec: v1beta1.AddressPoolSpec{
+							Addresses: []string{
+								"10.40.0.0/16",
+								"10.60.0.0/24",
+							},
+							Protocol:   string(BGP),
+							AutoAssign: pointer.BoolPtr(false),
+							BGPAdvertisements: []v1beta1.LegacyBgpAdvertisement{
+								{
+									AggregationLength: pointer.Int32Ptr(32),
+									LocalPref:         uint32(100),
+									Communities:       []string{"bar"},
+								},
+							},
+						},
+					},
+				},
+				Communities: []v1beta1.Community{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "community",
+						},
+						Spec: v1beta1.CommunitySpec{
+							Communities: []v1beta1.CommunityAlias{
+								{
+									Name:  "bar",
+									Value: "large:123:64512:1234",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &Config{
+				Pools: &Pools{ByName: map[string]*Pool{
+					"legacybgppool1": {
+						Name: "legacybgppool1",
+						CIDR: []*net.IPNet{ipnet("10.40.0.0/16"), ipnet("10.60.0.0/24")},
+						BGPAdvertisements: []*BGPAdvertisement{
+							{
+								AggregationLength:   32,
+								AggregationLengthV6: 128,
+								LocalPref:           100,
+								Communities: func() map[community.BGPCommunity]bool {
+									c, _ := community.New("large:123:64512:1234")
+									return map[community.BGPCommunity]bool{
+										c: true,
+									}
+								}(),
 								Nodes: map[string]bool{},
 							},
 						},
@@ -2658,7 +2872,7 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -2677,7 +2891,7 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           200,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 							},
 						},
@@ -3087,7 +3301,7 @@ func TestParse(t *testing.T) {
 							{
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes: map[string]bool{
 									"first":  true,
 									"second": true,
@@ -3117,7 +3331,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv1",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"second": true},
 							},
 						},
@@ -3137,7 +3351,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv2",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{"first": true},
 							},
 						},
@@ -3365,7 +3579,7 @@ func TestParse(t *testing.T) {
 								Name:                "adv1",
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes: map[string]bool{
 									"first":  true,
 									"second": true,
@@ -3450,7 +3664,7 @@ func TestParse(t *testing.T) {
 								AggregationLength:   32,
 								AggregationLengthV6: 128,
 								LocalPref:           100,
-								Communities:         map[uint32]bool{},
+								Communities:         map[community.BGPCommunity]bool{},
 								Nodes:               map[string]bool{},
 								Peers:               []string{"peer1"},
 							},

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	metallbv1beta2 "go.universe.tf/metallb/api/v1beta2"
+	"go.universe.tf/metallb/internal/bgp/community"
 	"go.universe.tf/metallb/internal/ipfamily"
 )
 
@@ -39,11 +40,20 @@ func DiscardFRROnly(c ClusterResources) error {
 	if len(c.BFDProfiles) > 0 {
 		return errors.New("bfd profiles section set")
 	}
+	// Only IPv4 BGP advertisements are supported in native mode.
+	if err := findIPv6BGPAdvertisement(c); err != nil {
+		return err
+	}
+	// Only legacy type communities are supported in native mode.
+	return findNonLegacyCommunity(c)
+}
+
+// findIPv6BGPAdvertisement checks for IPv6 addresses. If it finds at least one IPv6 BGP advertisement, it will throw
+// and error as it's not supported in native mode.
+func findIPv6BGPAdvertisement(c ClusterResources) error {
 	if len(c.BGPAdvs) == 0 {
 		return nil
 	}
-	// we check for ipv6 addresses if we have at least one bgp advertisement, as it's
-	// not supported in native mode.
 	for _, p := range c.Pools {
 		for _, cidr := range p.Spec.Addresses {
 			nets, err := ParseCIDR(cidr)
@@ -54,6 +64,54 @@ func DiscardFRROnly(c ClusterResources) error {
 				if n.IP.To4() == nil {
 					return fmt.Errorf("pool %q has ipv6 CIDR %s, native bgp mode does not support ipv6", p.Name, n)
 				}
+			}
+		}
+	}
+	return nil
+}
+
+// findNonLegacyCommunity returns an error if it can find a non legacy community. If a community string can not be
+// parsed, the string will be ignored.
+func findNonLegacyCommunity(c ClusterResources) error {
+	for _, p := range c.LegacyAddressPools {
+		for _, adv := range p.Spec.BGPAdvertisements {
+			for _, cs := range adv.Communities {
+				c, err := community.New(cs)
+				if err != nil {
+					// Skip aliases.
+					continue
+				}
+				if !community.IsLegacy(c) {
+					return fmt.Errorf("native BGP mode only supports legacy communities, legacy address pool %q "+
+						"has non legacy community %q", p.Name, cs)
+				}
+			}
+		}
+	}
+	for _, adv := range c.BGPAdvs {
+		for _, cs := range adv.Spec.Communities {
+			c, err := community.New(cs)
+			if err != nil {
+				// Skip aliases.
+				continue
+			}
+			if !community.IsLegacy(c) {
+				return fmt.Errorf("native BGP mode only supports legacy communities, BGP advertisement %q "+
+					"has non legacy community %q", adv.Name, cs)
+			}
+		}
+	}
+	for _, co := range c.Communities {
+		for _, cs := range co.Spec.Communities {
+			c, err := community.New(cs.Value)
+			if err != nil {
+				// Skip it if we cannot parse it - the purpose of this very verification is not to make sure that
+				// a string can be parsed or not.
+				continue
+			}
+			if !community.IsLegacy(c) {
+				return fmt.Errorf("native BGP mode only supports legacy communities, BGP community CR %q "+
+					"has non legacy community %q", co.Name, cs)
 			}
 		}
 	}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -83,6 +83,53 @@ func TestValidate(t *testing.T) {
 			mustFail: true,
 		},
 		{
+			desc: "large BGP community inside legacy pool",
+			config: ClusterResources{
+				LegacyAddressPools: []v1beta1.AddressPool{
+					{
+						Spec: v1beta1.AddressPoolSpec{
+							BGPAdvertisements: []v1beta1.LegacyBgpAdvertisement{
+								{
+									Communities: []string{"large:123:456:789"},
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
+			desc: "large BGP community inside BGP Advertisement",
+			config: ClusterResources{
+				BGPAdvs: []v1beta1.BGPAdvertisement{
+					{
+						Spec: v1beta1.BGPAdvertisementSpec{
+							Communities: []string{"large:123:456:789"},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
+			desc: "large BGP community inside Community CR",
+			config: ClusterResources{
+				Communities: []v1beta1.Community{
+					{
+						Spec: v1beta1.CommunitySpec{
+							Communities: []v1beta1.CommunityAlias{
+								{
+									Value: "large:123:456:789",
+								},
+							},
+						},
+					},
+				},
+			},
+			mustFail: true,
+		},
+		{
 			desc: "should pass",
 			config: ClusterResources{
 				Peers: []v1beta2.BGPPeer{

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -295,7 +295,7 @@ func (c *bgpController) SetBalancer(l log.Logger, name string, lbIPs []net.IP, p
 			for comm := range adCfg.Communities {
 				ad.Communities = append(ad.Communities, comm)
 			}
-			sort.Slice(ad.Communities, func(i, j int) bool { return ad.Communities[i] < ad.Communities[j] })
+			sort.Slice(ad.Communities, func(i, j int) bool { return ad.Communities[i].LessThan(ad.Communities[j]) })
 			c.svcAds[name] = append(c.svcAds[name], ad)
 		}
 	}

--- a/website/content/apis/_index.md
+++ b/website/content/apis/_index.md
@@ -260,8 +260,9 @@ Path with higher localpref is preferred over one with lower localpref.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>The BGP communities to be associated with the announcement. Each item can be a
-community of the form 1234:1234 or the name of an alias defined in the Community CRD.</p>
+<p>The BGP communities to be associated with the announcement. Each item can be a standard community of the
+form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+Community CRD.</p>
 </td>
 </tr>
 <tr>
@@ -436,7 +437,8 @@ string
 </em>
 </td>
 <td>
-<p>The BGP community value corresponding to the given name.</p>
+<p>The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+or a large community of the form large:1234:1234:1234.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
This patch only implements large communities but the format is compatible with a future implementation of extended communities.

Community types are distinguished by using Juniper style syntax, thus <AS number>:<community value>,<type>:<administrator>:<assigned-number>, large:<global administrator>:<localdata part 1>:<localdata part 2> for each of the respective types legacy, extended and large communities.

Also update CRD descriptions for large communities


