### PR TITLE
OCPBUGS-14503: [4.10]  read memberlist secret from file instead of env var

### DIFF
--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -89,6 +89,7 @@ A network load-balancer implementation for Kubernetes using standard routing pro
 | speaker.logLevel | string | `"info"` | Speaker log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none` |
 | speaker.memberlist.enabled | bool | `true` |  |
 | speaker.memberlist.mlBindPort | int | `7946` |  |
+| speaker.memberlist.mlSecretKeyPath | string | `"/etc/ml_secret_key"` |  |
 | speaker.nodeSelector | object | `{}` |  |
 | speaker.podAnnotations | object | `{}` |  |
 | speaker.readinessProbe.enabled | bool | `true` |  |

--- a/charts/metallb/policy/speaker.rego
+++ b/charts/metallb/policy/speaker.rego
@@ -16,18 +16,11 @@ deny[msg] {
   msg = sprintf("speaker ConfigMap arg '%s' does not match expected value", [configArg])
 }
 
-# validate METALLB_ML_SECRET_KEY (memberlist)
+# validate METALLB_ML_SECRET_KEY_PATH (memberlist)
 deny[msg] {
 	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY"
-	msg = "speaker env does not contain METALLB_ML_SECRET_KEY at env[5]"
-}
-
-deny[msg] {
-	input.kind == "DaemonSet"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.name == "RELEASE-NAME-metallb-memberlist"
-	not input.spec.template.spec.containers[0].env[5].valueFrom.secretKeyRef.key == "secretkey"
-	msg = "speaker env METALLB_ML_SECRET_KEY secretKeyRef does not equal expected value"
+	not input.spec.template.spec.containers[0].env[5].name == "METALLB_ML_SECRET_KEY_PATH"
+	msg = "speaker env does not contain METALLB_ML_SECRET_KEY_PATH at env[5]"
 }
 
 # validate node selector includes builtin when custom ones are provided

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -143,6 +143,13 @@ spec:
       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
       hostNetwork: true
+      volumes:
+      {{- if .Values.speaker.memberlist.enabled }}
+        - name: memberlist
+          secret:
+            secretName: {{ include "metallb.secretName" . }}
+            defaultMode: 420
+      {{- end }}
       {{- if .Values.speaker.frr.enabled }}
       volumes:
         - name: frr-sockets
@@ -215,11 +222,8 @@ spec:
           value: "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/component=speaker"
         - name: METALLB_ML_BIND_PORT
           value: "{{ .Values.speaker.memberlist.mlBindPort }}"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "metallb.secretName" . }}
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: "{{ .Values.speaker.memberlist.mlSecretKeyPath }}"
         {{- end }}
         {{- if .Values.speaker.frr.enabled }}
         - name: FRR_CONFIG_FILE
@@ -276,11 +280,17 @@ spec:
             - ALL
             add:
             - NET_RAW
-        {{- if .Values.speaker.frr.enabled }}
+        {{- if or .Values.speaker.frr.enabled .Values.speaker.memberlist.enabled }}
         volumeMounts:
+          {{- if .Values.speaker.memberlist.enabled }}
+          - name: memberlist 
+            mountPath: {{ .Values.speaker.memberlist.mlSecretKeyPath }}
+          {{- end }}
+          {{- if .Values.speaker.frr.enabled }}
           - name: reloader
             mountPath: /etc/frr_reloader
-         {{- end }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.speaker.frr.enabled }}
       - name: frr
         securityContext:

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -294,6 +294,9 @@
                 },
                 "mlBindPort": {
                   "type": "integer"
+                },
+                "mlSecretKeyPath": {
+                  "type": "string"
                 }
               }
             },

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -187,6 +187,7 @@ speaker:
   memberlist:
     enabled: true
     mlBindPort: 7946
+    mlSecretKeyPath: "/etc/ml_secret_key"
   image:
     repository: quay.io/metallb/speaker
     tag:

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+const MLSecretKeyName = "secretkey"
+
 // Client watches a Kubernetes cluster and translates events into
 // Controller method calls.
 type Client struct {
@@ -382,7 +384,7 @@ func (c *Client) CreateMlSecret(namespace, controllerDeploymentName, secretName 
 					UID:  d.UID,
 				}},
 			},
-			Data: map[string][]byte{"secretkey": secretB64},
+			Data: map[string][]byte{MLSecretKeyName: secretB64},
 		},
 		metav1.CreateOptions{})
 	if err == nil {

--- a/manifests/metallb-frr.yaml
+++ b/manifests/metallb-frr.yaml
@@ -444,6 +444,10 @@ spec:
           emptyDir: {}
         - name: metrics
           emptyDir: {}
+        - name: memberlist
+          secret:
+            defaultMode: 420
+            secretName: memberlist
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.
         - name: cp-frr-files
@@ -559,16 +563,16 @@ spec:
             #  value: "7946"
             - name: METALLB_ML_LABELS
               value: "app=metallb,component=speaker"
-            - name: METALLB_ML_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: memberlist
-                  key: secretkey
+            - name: METALLB_ML_SECRET_KEY_PATH
+              value: "/etc/ml_secret_key"
           image: quay.io/metallb/speaker:main
           name: speaker
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
+            - name: memberlist 
+              mountPath: /etc/ml_secret_key
+              readOnly: true
           ports:
             - containerPort: 7472
               name: monitoring

--- a/manifests/metallb.yaml
+++ b/manifests/metallb.yaml
@@ -357,13 +357,14 @@ spec:
         #  value: "7946"
         - name: METALLB_ML_LABELS
           value: "app=metallb,component=speaker"
-        - name: METALLB_ML_SECRET_KEY
-          valueFrom:
-            secretKeyRef:
-              name: memberlist
-              key: secretkey
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: "/etc/ml_secret_key"
         image: quay.io/metallb/speaker:main
         name: speaker
+        volumeMounts:
+          - name: memberlist 
+            mountPath: /etc/ml_secret_key
+            readOnly: true
         ports:
         - containerPort: 7472
           name: monitoring
@@ -407,6 +408,11 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
         operator: Exists
+      volumes:
+        - name: memberlist
+          secret:
+            defaultMode: 420
+            secretName: memberlist
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/speaker/main.go
+++ b/speaker/main.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"go.universe.tf/metallb/internal/bgp"
@@ -68,7 +69,7 @@ func main() {
 		mlBindAddr      = flag.String("ml-bindaddr", os.Getenv("METALLB_ML_BIND_ADDR"), "Bind addr for MemberList (fast dead node detection)")
 		mlBindPort      = flag.String("ml-bindport", os.Getenv("METALLB_ML_BIND_PORT"), "Bind port for MemberList (fast dead node detection)")
 		mlLabels        = flag.String("ml-labels", os.Getenv("METALLB_ML_LABELS"), "Labels to match the speakers (for MemberList / fast dead node detection)")
-		mlSecret        = flag.String("ml-secret-key", os.Getenv("METALLB_ML_SECRET_KEY"), "Secret key for MemberList (fast dead node detection)")
+		mlSecretKeyPath = flag.String("ml-secret-key-path", os.Getenv("METALLB_ML_SECRET_KEY_PATH"), "Path to where the MembeList's secret key is mounted")
 		myNode          = flag.String("node-name", os.Getenv("METALLB_NODE_NAME"), "name of this Kubernetes node (spec.nodeName)")
 		port            = flag.Int("port", 7472, "HTTP listening port")
 		logLevel        = flag.String("log-level", "info", fmt.Sprintf("log level. must be one of: [%s]", logging.Levels.String()))
@@ -117,7 +118,18 @@ func main() {
 	}()
 	defer level.Info(logger).Log("op", "shutdown", "msg", "done")
 
-	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, *mlSecret, *namespace, *mlLabels, stopCh)
+	var mlSecret string
+
+	if *mlSecretKeyPath != "" {
+		mlSecretBytes, err := os.ReadFile(filepath.Join(*mlSecretKeyPath, k8s.MLSecretKeyName))
+		if err != nil {
+			level.Error(logger).Log("op", "startup", "error", err, "msg", "failed to read memberlist secret key file")
+			os.Exit(1)
+		}
+		mlSecret = string(mlSecretBytes)
+	}
+
+	sList, err := speakerlist.New(logger, *myNode, *mlBindAddr, *mlBindPort, mlSecret, *namespace, *mlLabels, stopCh)
 	if err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is a cherry-pick from 4.11 
#124 

Makes the memberlist secret env var hold the path to the secret instead the secret itself.
and makes the speaker consume the secret by reading from that path.