### PR TITLE
OCPBUGS-18985: FRR templates: provide a seqnum for the prefix lists

### DIFF
--- a/internal/bgp/frr/config.go
+++ b/internal/bgp/frr/config.go
@@ -107,17 +107,14 @@ func neighborName(peerAddr string, ASN uint32, vrfName string) string {
 // templateConfig uses the template library to template
 // 'globalConfigTemplate' using 'data'.
 func templateConfig(data interface{}) (string, error) {
-	i := 0
-	currentCounterName := ""
+	counterMap := map[string]int{}
 	t, err := template.New("frr.tmpl").Funcs(
 		template.FuncMap{
 			"counter": func(counterName string) int {
-				if currentCounterName != counterName {
-					currentCounterName = counterName
-					i = 0
-				}
-				i++
-				return i
+				counter := counterMap[counterName]
+				counter++
+				counterMap[counterName] = counter
+				return counter
 			},
 			"frrIPFamily": func(ipFamily ipfamily.Family) string {
 				if ipFamily == "ipv6" {

--- a/internal/bgp/frr/templates/filters.tmpl
+++ b/internal/bgp/frr/templates/filters.tmpl
@@ -1,5 +1,6 @@
 {{- define "localpreffilter" -}}
-{{frrIPFamily .advertisement.IPFamily}} prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}} permit {{.advertisement.Prefix}}
+{{$localPrefixListName :=localPrefPrefixList .neighbor .advertisement.LocalPref}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{$localPrefixListName}} seq {{counter $localPrefixListName}} permit {{.advertisement.Prefix}}
 route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}}
   set local-preference {{.advertisement.LocalPref}}
@@ -7,7 +8,8 @@ route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
 {{- end -}}
 
 {{- define "communityfilter" -}}
-{{frrIPFamily .advertisement.IPFamily}} prefix-list {{communityPrefixList .neighbor .community}} permit {{.advertisement.Prefix}}
+{{$communityPrefixlistName :=communityPrefixList .neighbor .community}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{$communityPrefixlistName}} seq {{counter $communityPrefixlistName}} permit {{.advertisement.Prefix}}
 route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{communityPrefixList .neighbor .community}}
   set community {{.community}} additive
@@ -32,7 +34,8 @@ route-map {{.neighbor.ID}}-in deny 20
 {{template "communityfilter" dict "advertisement" $a "neighbor" $.neighbor "community" $c}}
 {{- end }}
 {{/* this advertisement is allowed to the specific neighbor  */}}
-{{frrIPFamily $a.IPFamily}} prefix-list {{allowedPrefixList $.neighbor}} permit {{$a.Prefix}}
+{{$plistName:=allowedPrefixList $.neighbor}}
+{{frrIPFamily $a.IPFamily}} prefix-list {{$plistName}} seq {{counter $plistName}} permit {{$a.Prefix}}
 {{- end }}
 
 route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
@@ -40,6 +43,8 @@ route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
 route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
   match ipv6 address prefix-list {{allowedPrefixList $.neighbor}}
 
-ip prefix-list {{allowedPrefixList $.neighbor }} deny any
-ipv6 prefix-list {{allowedPrefixList $.neighbor}} deny any
+{{$plistName:=allowedPrefixList $.neighbor}}
+
+ip prefix-list {{$plistName}} seq {{counter $plistName}} deny any
+ipv6 prefix-list {{$plistName}} seq {{counter $plistName}} deny any
 {{- end -}}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisement.golden
@@ -5,31 +5,37 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 5
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChange.golden
@@ -6,15 +6,18 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementChangeVRF.golden
@@ -6,15 +6,18 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
 
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 2
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNoRouterID.golden
@@ -6,15 +6,18 @@ ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementNonExistingPeer.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementNonExistingPeer.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementStop.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementVRF.golden
@@ -5,31 +5,37 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
 
-ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 3
   match ip address prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-red-out permit 4
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 5
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelector.golden
@@ -5,31 +5,37 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 5
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelectorVRF.golden
+++ b/internal/bgp/frr/testdata/TestSingleAdvertisementWithPeerSelectorVRF.golden
@@ -5,31 +5,37 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
 
-ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-300-ipv4-localpref-prefixes
   set local-preference 300
   on-match next
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
-ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 3
   match ip address prefix-list 10.2.2.254-red-3333:4444-ipv4-community-prefixes
   set community 3333:4444 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-red-out permit 4
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 5
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionMultiHop.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleEBGPSessionOneHop.golden
@@ -10,8 +10,10 @@ route-map 127.0.0.2-out permit 1
 route-map 127.0.0.2-out permit 2
   match ipv6 address prefix-list 127.0.0.2-pl-ipv4
 
-ip prefix-list 127.0.0.2-pl-ipv4 deny any
-ipv6 prefix-list 127.0.0.2-pl-ipv4 deny any
+
+
+ip prefix-list 127.0.0.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 127.0.0.2-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIBGPSession.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6EBGPSessionOneHop.golden
@@ -10,8 +10,10 @@ route-map 127:0:0::2-out permit 1
 route-map 127:0:0::2-out permit 2
   match ipv6 address prefix-list 127:0:0::2-pl-ipv6
 
-ip prefix-list 127:0:0::2-pl-ipv6 deny any
-ipv6 prefix-list 127:0:0::2-pl-ipv6 deny any
+
+
+ip prefix-list 127:0:0::2-pl-ipv6 seq 1 deny any
+ipv6 prefix-list 127:0:0::2-pl-ipv6 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleIPv6IBGPSession.golden
@@ -10,8 +10,10 @@ route-map 10:2:2::254-out permit 1
 route-map 10:2:2::254-out permit 2
   match ipv6 address prefix-list 10:2:2::254-pl-ipv6
 
-ip prefix-list 10:2:2::254-pl-ipv6 deny any
-ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
+
+
+ip prefix-list 10:2:2::254-pl-ipv6 seq 1 deny any
+ipv6 prefix-list 10:2:2::254-pl-ipv6 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleSessionExtras.golden
+++ b/internal/bgp/frr/testdata/TestSingleSessionExtras.golden
@@ -11,8 +11,9 @@ route-map 127.0.0.2-out permit 2
   match ipv6 address prefix-list 127.0.0.2-pl-ipv4
 
 
-ip prefix-list 127.0.0.2-pl-ipv4 deny any
-ipv6 prefix-list 127.0.0.2-pl-ipv4 deny any
+
+ip prefix-list 127.0.0.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 127.0.0.2-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
+++ b/internal/bgp/frr/testdata/TestSingleVRFIBGPSession.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-red-out permit 1
 route-map 10.2.2.254-red-out permit 2
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisements.golden
@@ -5,24 +5,29 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 3
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessions.golden
@@ -5,64 +5,78 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 5
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 4 deny any
 route-map 10.2.2.255-in deny 20
 
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.255-out permit 1
   match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.255-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 2
   match ip address prefix-list 10.2.2.255-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 3
   match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.255-out permit 4
   match ip address prefix-list 10.2.2.255-pl-ipv4
 route-map 10.2.2.255-out permit 5
   match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 
-ip prefix-list 10.2.2.255-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 seq 4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneVRF.golden
@@ -5,64 +5,78 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 5
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 4 deny any
 route-map 10.2.2.255-red-in deny 20
 
-ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.255-red-out permit 1
   match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-red-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.255-red-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-red-out permit 2
   match ip address prefix-list 10.2.2.255-red-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.255-red-out permit 3
   match ip address prefix-list 10.2.2.255-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-red-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.255-red-out permit 4
   match ip address prefix-list 10.2.2.255-red-pl-ipv4
 route-map 10.2.2.255-red-out permit 5
   match ipv6 address prefix-list 10.2.2.255-red-pl-ipv4
 
-ip prefix-list 10.2.2.255-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.255-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.255-red-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.255-red-pl-ipv4 seq 4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelector.golden
@@ -5,56 +5,68 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-in deny 20
 
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-out permit 1
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.254-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 2
   match ip address prefix-list 10.2.2.254-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.254-out permit 3
   match ip address prefix-list 10.2.2.254-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-out permit 4
   match ip address prefix-list 10.2.2.254-pl-ipv4
 route-map 10.2.2.254-out permit 5
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 4 deny any
 route-map 10.2.2.255-in deny 20
 
-ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 1
   match ip address prefix-list 10.2.2.255-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 2
   match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 route-map 10.2.2.255-out permit 3
   match ip address prefix-list 10.2.2.255-pl-ipv4
 route-map 10.2.2.255-out permit 4
   match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 
-ip prefix-list 10.2.2.255-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 seq 3 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsOneWithPeerSelectorAndVRF.golden
@@ -5,56 +5,68 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.255-in deny 20
 
-ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 1
   match ip address prefix-list 10.2.2.255-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-out permit 2
   match ip address prefix-list 10.2.2.255-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 route-map 10.2.2.255-out permit 3
   match ip address prefix-list 10.2.2.255-pl-ipv4
 route-map 10.2.2.255-out permit 4
   match ipv6 address prefix-list 10.2.2.255-pl-ipv4
 
-ip prefix-list 10.2.2.255-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.255-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.255-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.255-pl-ipv4 seq 3 deny any
 route-map 10.2.2.254-red-in deny 20
 
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
 
-ip prefix-list 10.2.2.254-red-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+
+ip prefix-list 10.2.2.254-red-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 2 permit 172.16.1.11/24
 route-map 10.2.2.254-red-out permit 3
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-red-out permit 4
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 5
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 4 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsTwoSessionsVRFWithPeerSelector.golden
@@ -5,43 +5,52 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.255-blue-in deny 20
 
-ip prefix-list 10.2.2.255-blue-2-ipv4-localpref-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-blue-2-ipv4-localpref-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-blue-out permit 1
   match ip address prefix-list 10.2.2.255-blue-2-ipv4-localpref-prefixes
   set local-preference 2
   on-match next
-ip prefix-list 10.2.2.255-blue-1111:2222-ipv4-community-prefixes permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-blue-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.11/24
 route-map 10.2.2.255-blue-out permit 2
   match ip address prefix-list 10.2.2.255-blue-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.255-blue-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.255-blue-pl-ipv4 seq 1 permit 172.16.1.11/24
 
 route-map 10.2.2.255-blue-out permit 3
   match ip address prefix-list 10.2.2.255-blue-pl-ipv4
 route-map 10.2.2.255-blue-out permit 4
   match ipv6 address prefix-list 10.2.2.255-blue-pl-ipv4
 
-ip prefix-list 10.2.2.255-blue-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.255-blue-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.255-blue-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.255-blue-pl-ipv4 seq 3 deny any
 route-map 10.2.2.254-red-in deny 20
 
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 3
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
 
 router bgp 100 vrf blue
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsVRF.golden
@@ -5,24 +5,29 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 route-map 10.2.2.254-red-in deny 20
 
-ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes seq 1 permit 172.16.1.10/24
 route-map 10.2.2.254-red-out permit 1
   match ip address prefix-list 10.2.2.254-red-1111:2222-ipv4-community-prefixes
   set community 1111:2222 additive
   on-match next
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.10/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 permit 172.16.1.10/24
 
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 permit 172.16.1.11/24
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 2 permit 172.16.1.11/24
 
 route-map 10.2.2.254-red-out permit 2
   match ip address prefix-list 10.2.2.254-red-pl-ipv4
 route-map 10.2.2.254-red-out permit 3
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 3 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 4 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoIPv6Sessions.golden
@@ -10,8 +10,10 @@ route-map 10:2:2::254-out permit 1
 route-map 10:2:2::254-out permit 2
   match ipv6 address prefix-list 10:2:2::254-pl-ipv6
 
-ip prefix-list 10:2:2::254-pl-ipv6 deny any
-ipv6 prefix-list 10:2:2::254-pl-ipv6 deny any
+
+
+ip prefix-list 10:2:2::254-pl-ipv6 seq 1 deny any
+ipv6 prefix-list 10:2:2::254-pl-ipv6 seq 2 deny any
 route-map 10:4:4::255-in deny 20
 
 route-map 10:4:4::255-out permit 1
@@ -19,8 +21,10 @@ route-map 10:4:4::255-out permit 1
 route-map 10:4:4::255-out permit 2
   match ipv6 address prefix-list 10:4:4::255-pl-ipv6
 
-ip prefix-list 10:4:4::255-pl-ipv6 deny any
-ipv6 prefix-list 10:4:4::255-pl-ipv6 deny any
+
+
+ip prefix-list 10:4:4::255-pl-ipv6 seq 1 deny any
+ipv6 prefix-list 10:4:4::255-pl-ipv6 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessions.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessions.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 route-map 10.4.4.255-in deny 20
 
 route-map 10.4.4.255-out permit 1
@@ -19,8 +21,10 @@ route-map 10.4.4.255-out permit 1
 route-map 10.4.4.255-out permit 2
   match ipv6 address prefix-list 10.4.4.255-pl-ipv4
 
-ip prefix-list 10.4.4.255-pl-ipv4 deny any
-ipv6 prefix-list 10.4.4.255-pl-ipv4 deny any
+
+
+ip prefix-list 10.4.4.255-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.4.4.255-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicate.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsDuplicateRouter.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 route-map 10.4.4.255-in deny 20
 
 route-map 10.4.4.255-out permit 1
@@ -19,8 +21,10 @@ route-map 10.4.4.255-out permit 1
 route-map 10.4.4.255-out permit 2
   match ipv6 address prefix-list 10.4.4.255-pl-ipv4
 
-ip prefix-list 10.4.4.255-pl-ipv4 deny any
-ipv6 prefix-list 10.4.4.255-pl-ipv4 deny any
+
+
+ip prefix-list 10.4.4.255-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.4.4.255-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsOneVRF.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 route-map 10.4.4.255-red-in deny 20
 
 route-map 10.4.4.255-red-out permit 1
@@ -19,8 +21,10 @@ route-map 10.4.4.255-red-out permit 1
 route-map 10.4.4.255-red-out permit 2
   match ipv6 address prefix-list 10.4.4.255-red-pl-ipv4
 
-ip prefix-list 10.4.4.255-red-pl-ipv4 deny any
-ipv6 prefix-list 10.4.4.255-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.4.4.255-red-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.4.4.255-red-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPRouterIDASNVRF.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 route-map 10.2.2.254-red-in deny 20
 
 route-map 10.2.2.254-red-out permit 1
@@ -19,8 +21,10 @@ route-map 10.2.2.254-red-out permit 1
 route-map 10.2.2.254-red-out permit 2
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
+++ b/internal/bgp/frr/testdata/TestTwoSessionsSameIPVRF.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-out permit 1
 route-map 10.2.2.254-out permit 2
   match ipv6 address prefix-list 10.2.2.254-pl-ipv4
 
-ip prefix-list 10.2.2.254-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
 route-map 10.2.2.254-red-in deny 20
 
 route-map 10.2.2.254-red-out permit 1
@@ -19,8 +21,10 @@ route-map 10.2.2.254-red-out permit 1
 route-map 10.2.2.254-red-out permit 2
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
 
 router bgp 100
   no bgp ebgp-requires-policy

--- a/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
+++ b/internal/bgp/frr/testdata/TestVRFSingleEBGPSessionMultiHop.golden
@@ -10,8 +10,10 @@ route-map 10.2.2.254-red-out permit 1
 route-map 10.2.2.254-red-out permit 2
   match ipv6 address prefix-list 10.2.2.254-red-pl-ipv4
 
-ip prefix-list 10.2.2.254-red-pl-ipv4 deny any
-ipv6 prefix-list 10.2.2.254-red-pl-ipv4 deny any
+
+
+ip prefix-list 10.2.2.254-red-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 10.2.2.254-red-pl-ipv4 seq 2 deny any
 
 router bgp 100 vrf red
   no bgp ebgp-requires-policy


### PR DESCRIPTION
Instead of letting frr pick the sequence number, we provide it from outside. This should make the configuration more deterministic and offload some of the logic from FRR.
