### PR TITLE
OCPBUGS-19745: Preserve internal state after reboot

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("BGP", func() {
 
 		allNodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		framework.ExpectNoError(err)
-		validateDesiredLB(svc)
+		testservice.ValidateDesiredLB(svc)
 
 		for _, c := range FRRContainers {
 			validateService(svc, allNodes.Items, c)
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("BGP", func() {
 				testservice.TrafficPolicyCluster(svc)
 			})
 			defer testservice.Delete(cs, svc)
-			validateDesiredLB(svc)
+			testservice.ValidateDesiredLB(svc)
 
 			for _, c := range FRRContainers {
 				validateService(svc, allNodes.Items, c)
@@ -193,7 +193,7 @@ var _ = ginkgo.Describe("BGP", func() {
 		})
 		defer testservice.Delete(cs, svc)
 
-		validateDesiredLB(svc)
+		testservice.ValidateDesiredLB(svc)
 
 		err := jig.Scale(2)
 		framework.ExpectNoError(err)
@@ -280,8 +280,8 @@ var _ = ginkgo.Describe("BGP", func() {
 			})
 		defer testservice.Delete(cs, svc1)
 
-		validateDesiredLB(svc)
-		validateDesiredLB(svc1)
+		testservice.ValidateDesiredLB(svc)
+		testservice.ValidateDesiredLB(svc1)
 
 		for _, c := range FRRContainers {
 			validateService(svc, allNodes.Items, c)

--- a/e2etest/bgptests/validate.go
+++ b/e2etest/bgptests/validate.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	"go.universe.tf/e2etest/pkg/executor"
 	"go.universe.tf/e2etest/pkg/frr"
 	frrcontainer "go.universe.tf/e2etest/pkg/frr/container"
@@ -21,6 +20,7 @@ import (
 	"go.universe.tf/e2etest/pkg/metallb"
 	"go.universe.tf/e2etest/pkg/routes"
 	"go.universe.tf/e2etest/pkg/wget"
+	metallbv1beta1 "go.universe.tf/metallb/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -168,14 +168,6 @@ func checkBFDConfigPropagated(nodeConfig metallbv1beta1.BFDProfile, peerConfig f
 	return nil
 }
 
-func validateDesiredLB(svc *corev1.Service) {
-	desiredLbIPs := svc.Annotations["metallb.universe.tf/loadBalancerIPs"]
-	if desiredLbIPs == "" {
-		return
-	}
-	framework.ExpectEqual(desiredLbIPs, strings.Join(getIngressIPs(svc.Status.LoadBalancer.Ingress), ","))
-}
-
 func checkServiceOnlyOnNodes(svc *corev1.Service, expectedNodes []corev1.Node, ipFamily ipfamily.Family) {
 	if len(expectedNodes) == 0 {
 		return
@@ -284,14 +276,6 @@ OUTER:
 	}
 
 	return nonSelectedNodes
-}
-
-func getIngressIPs(ingresses []corev1.LoadBalancerIngress) []string {
-	var ips []string
-	for _, ingress := range ingresses {
-		ips = append(ips, ingress.IP)
-	}
-	return ips
 }
 
 func validateServiceNotAdvertised(svc *corev1.Service, frrContainers []*frrcontainer.FRR, advertised string, ipFamily ipfamily.Family) {

--- a/e2etest/pkg/k8s/pods.go
+++ b/e2etest/pkg/k8s/pods.go
@@ -37,3 +37,23 @@ func PodLogs(cs clientset.Interface, pod *corev1.Pod, podLogOpts corev1.PodLogOp
 	str := buf.String()
 	return str, nil
 }
+
+// PodIsReady returns the given pod's PodReady condition.
+func PodIsReady(p *corev1.Pod) bool {
+	return podConditionStatus(p, corev1.PodReady) == corev1.ConditionTrue
+}
+
+// podConditionStatus returns the status of the condition for a given pod.
+func podConditionStatus(p *corev1.Pod, condition corev1.PodConditionType) corev1.ConditionStatus {
+	if p == nil {
+		return corev1.ConditionUnknown
+	}
+
+	for _, c := range p.Status.Conditions {
+		if c.Type == condition {
+			return c.Status
+		}
+	}
+
+	return corev1.ConditionUnknown
+}

--- a/e2etest/pkg/metallb/metallb.go
+++ b/e2etest/pkg/metallb/metallb.go
@@ -6,11 +6,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
+	"go.universe.tf/e2etest/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var (
@@ -53,7 +57,7 @@ func ControllerPod(cs clientset.Interface) (*corev1.Pod, error) {
 		LabelSelector: ControllerLabelSelector,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch controller pods")
+		framework.ExpectNoError(err, "failed to fetch controller pods")
 	}
 	if len(pods.Items) != 1 {
 		return nil, fmt.Errorf("expected one controller pod, found %d", len(pods.Items))
@@ -73,4 +77,27 @@ func SpeakerPodInNode(cs clientset.Interface, node string) (*corev1.Pod, error) 
 		}
 	}
 	return nil, errors.Errorf("no speaker pod run in the node %s", node)
+}
+
+// RestartController restarts metallb's controller pod and waits for it to be running and ready.
+func RestartController(cs clientset.Interface) {
+	controllerPod, err := ControllerPod(cs)
+	framework.ExpectNoError(err)
+
+	err = cs.CoreV1().Pods(controllerPod.Namespace).Delete(context.TODO(), controllerPod.Name, metav1.DeleteOptions{})
+	framework.ExpectNoError(err)
+
+	err = wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
+		pod, err := ControllerPod(cs)
+		if err != nil {
+			return false, nil
+		}
+		if controllerPod.Name == pod.Name {
+			return false, nil
+		}
+		isReady := (pod.Status.Phase == corev1.PodRunning) && (k8s.PodIsReady(pod))
+
+		return isReady, nil
+	})
+	framework.ExpectNoError(err)
 }

--- a/e2etest/pkg/service/validate.go
+++ b/e2etest/pkg/service/validate.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"go.universe.tf/e2etest/pkg/executor"
 	"go.universe.tf/e2etest/pkg/wget"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 )
 
@@ -24,4 +26,36 @@ func ValidateL2(svc *corev1.Service) error {
 		return err
 	}
 	return nil
+}
+
+func ValidateDesiredLB(svc *corev1.Service) {
+	desiredLbIPs := svc.Annotations["metallb.universe.tf/loadBalancerIPs"]
+	if desiredLbIPs == "" {
+		return
+	}
+	framework.ExpectEqual(desiredLbIPs, strings.Join(getIngressIPs(svc.Status.LoadBalancer.Ingress), ","))
+}
+
+// ValidateAssignedWith validates that the service is assigned with the given ip.
+func ValidateAssignedWith(svc *corev1.Service, ip string) error {
+	if ip == "" {
+		return nil
+	}
+
+	ingressIPs := getIngressIPs(svc.Status.LoadBalancer.Ingress)
+	for _, ingressIP := range ingressIPs {
+		if ingressIP == ip {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("validation failed: ip %s is not assigned to service %s", ip, svc.Name)
+}
+
+func getIngressIPs(ingresses []corev1.LoadBalancerIngress) []string {
+	var ips []string
+	for _, ingress := range ingresses {
+		ips = append(ips, ingress.IP)
+	}
+	return ips
 }

--- a/internal/k8s/nodes/nodes.go
+++ b/internal/k8s/nodes/nodes.go
@@ -6,8 +6,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// ConditionStatus returns the status of the condition for a given node.
-func ConditionStatus(n *corev1.Node, ct corev1.NodeConditionType) corev1.ConditionStatus {
+// IsNetworkUnavailable returns true if the given node NodeNetworkUnavailable condition status is true.
+func IsNetworkUnavailable(n *corev1.Node) bool {
+	return conditionStatus(n, corev1.NodeNetworkUnavailable) == corev1.ConditionTrue
+}
+
+// conditionStatus returns the status of the condition for a given node.
+func conditionStatus(n *corev1.Node, ct corev1.NodeConditionType) corev1.ConditionStatus {
 	if n == nil {
 		return corev1.ConditionUnknown
 	}
@@ -19,9 +24,4 @@ func ConditionStatus(n *corev1.Node, ct corev1.NodeConditionType) corev1.Conditi
 	}
 
 	return corev1.ConditionUnknown
-}
-
-// IsNetworkUnavailable returns true if the given node NodeNetworkUnavailable condition status is true.
-func IsNetworkUnavailable(n *corev1.Node) bool {
-	return ConditionStatus(n, corev1.NodeNetworkUnavailable) == corev1.ConditionTrue
 }


### PR DESCRIPTION
This PR changes the behavior of the service reconciler
to fix the following bug:

- There is an LB service with a specific IP (annotated) assigned to it.

- Also there are other LB services in the cluster on "pending".

- MetalLB's controller resets and when it goes back up again,
  it loops over the services, sees first the "pending" LB service,
  and assigns it the IP that was assigned to the annotated service.

Here we make the reconciler ignore the services, up until the first
reprocessAll event, where we handle only the services with IP assigned
to them already.