### PR TITLE
OCPBUGS-18461: Dockerfile: use the rhel9 based builder to build the binaries

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /metallb
 
 COPY .git/ .git/
@@ -22,7 +22,7 @@ RUN export SOURCE_GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEA
       -ldflags "-X go.universe.tf/metallb/internal/version.gitCommit=${SOURCE_GIT_COMMIT} \
       -X go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}"
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.15
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.15
 COPY --from=builder /metallb/controller/controller /metallb/speaker/speaker \
       /metallb/frr-tools/reloader/frr-reloader.sh /metallb/frr-tools/metrics/frr-metrics /
 
@@ -35,4 +35,3 @@ LABEL io.k8s.display-name="Metallb" \
       io.k8s.description="This is a component of OpenShift Container Platform and provides a metallb plugin." \
       io.openshift.tags="openshift" \
       maintainer="Mohamed S. Mahmoud <mmahmoud@redhat.com>"
-


### PR DESCRIPTION
Using rhel9 based builder
