### PR TITLE
OCPBUGS-25266: Add a .snyk file with the files to skip

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**
+    - "**/*_test.go"
+    - "e2etest/**"


### PR DESCRIPTION
Skipping:
- the vendor folder
- any test file
- all the e2etest files
