### PR TITLE
[release-4.13] OCPBUGS-33759: FRR: squash advertisements with the same prefix

### DIFF
--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -18,6 +18,7 @@ import (
 	metallbconfig "go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/ipfamily"
 	"go.universe.tf/metallb/internal/logging"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // As the MetalLB controller should handle messages synchronously, there should
@@ -271,9 +272,6 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			rout.neighbors[neighborName] = neighbor
 		}
 
-		/* As 'session.advertised' is a map, we can be sure there are no
-		   duplicate prefixes and can, therefore, just add them to the
-		   'neighbor.Advertisements' list. */
 		for _, adv := range s.advertised {
 			if !adv.MatchesPeer(s.SessionName) {
 				continue
@@ -297,7 +295,11 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				LocalPref:   adv.LocalPref,
 			}
 
-			neighbor.Advertisements = append(neighbor.Advertisements, &advConfig)
+			neighbor.Advertisements, err = addToAdvertisements(neighbor.Advertisements, &advConfig)
+			if err != nil {
+				return nil, err
+			}
+
 			switch family {
 			case ipfamily.IPv4:
 				rout.ipV4Prefixes[prefix] = prefix
@@ -305,7 +307,6 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				rout.ipV6Prefixes[prefix] = prefix
 			}
 		}
-		sortAdvertiesements(neighbor.Advertisements)
 	}
 
 	for _, r := range sortMap(routers) {
@@ -434,25 +435,49 @@ func sortMap[T any](toSort map[string]T) []T {
 	return res
 }
 
-func sortAdvertiesements(toSort []*advertisementConfig) {
-	sort.Slice(toSort, func(i, j int) bool {
-		if toSort[i].IPFamily != toSort[j].IPFamily {
-			return toSort[i].IPFamily < toSort[j].IPFamily
+func addToAdvertisements(current []*advertisementConfig, toAdd *advertisementConfig) ([]*advertisementConfig, error) {
+	i := sort.Search(len(current), func(i int) bool { return current[i].Prefix >= toAdd.Prefix })
+	if i == len(current) {
+		return append(current, toAdd), nil
+	}
+
+	if current[i].Prefix == toAdd.Prefix {
+		var err error
+		current[i], err = mergeAdvertisements(current[i], toAdd)
+		if err != nil {
+			return nil, err
 		}
-		if toSort[i].Prefix != toSort[j].Prefix {
-			return toSort[i].Prefix < toSort[j].Prefix
-		}
-		if toSort[i].LocalPref != toSort[j].LocalPref {
-			return toSort[i].LocalPref < toSort[j].LocalPref
-		}
-		if len(toSort[i].Communities) != len(toSort[j].Communities) {
-			return len(toSort[i].Communities) < len(toSort[j].Communities)
-		}
-		for k := range toSort[i].Communities {
-			if toSort[i].Communities[k] != toSort[j].Communities[k] {
-				return toSort[i].Communities[k] < toSort[j].Communities[k]
-			}
-		}
-		return false
-	})
+		return current, nil
+	}
+	res := make([]*advertisementConfig, len(current)+1)
+	copy(res[:i], current[:i])
+	copy(res[i+1:], current[i:])
+	res[i] = toAdd
+	return res, nil
+}
+
+func mergeAdvertisements(adv1, adv2 *advertisementConfig) (*advertisementConfig, error) {
+	res := &advertisementConfig{}
+	if adv1.Prefix != adv2.Prefix {
+		return nil, fmt.Errorf("cannot merge advertisements with different prefixes: %s != %s", adv1.Prefix, adv2.Prefix)
+	}
+	if adv1.IPFamily != adv2.IPFamily {
+		return nil, fmt.Errorf("cannot merge advertisements with different ipfamilies: %s != %s", adv1.IPFamily, adv2.IPFamily)
+	}
+	if adv1.LocalPref != adv2.LocalPref {
+		return nil, fmt.Errorf("cannot merge advertisements with different local preferences: %d != %d", adv1.LocalPref, adv2.LocalPref)
+	}
+
+	res.Prefix = adv1.Prefix
+	res.IPFamily = adv1.IPFamily
+	res.LocalPref = adv1.LocalPref
+	res.Communities = mergeCommunities(adv1.Communities, adv2.Communities)
+	return res, nil
+}
+
+func mergeCommunities(c1, c2 []string) []string {
+	communities := sets.String{}
+	communities.Insert(c1...)
+	communities.Insert(c2...)
+	return communities.List()
 }

--- a/internal/bgp/frr/frr_test.go
+++ b/internal/bgp/frr/frr_test.go
@@ -10,13 +10,16 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-kit/log"
 	"go.universe.tf/metallb/internal/bgp"
 	"go.universe.tf/metallb/internal/config"
+	"go.universe.tf/metallb/internal/ipfamily"
 	"go.universe.tf/metallb/internal/logging"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -824,6 +827,50 @@ func TestTwoAdvertisements(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+func TestTwoAdvertisementsDuplicate(t *testing.T) {
+	testSetup(t)
+
+	l := log.NewNopLogger()
+	sessionManager := NewSessionManager(l, logging.LevelInfo)
+	defer close(sessionManager.reloadConfig)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      time.Second,
+			KeepAliveTime: time.Second,
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix1 := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	adv1 := &bgp.Advertisement{
+		Prefix: prefix1,
+	}
+
+	adv2 := &bgp.Advertisement{
+		Prefix: prefix1,
+	}
+
+	err = session.Set(adv1, adv2)
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
 func TestTwoAdvertisementsTwoSessions(t *testing.T) {
 	testSetup(t)
 
@@ -1085,4 +1132,175 @@ func TestLoggingConfigurationOverrideByEnvironmentVar(t *testing.T) {
 
 	sessionManager.reloadConfig <- reloadEvent{config: config}
 	testCheckConfigFile(t)
+}
+
+func TestAddToAdvertisements(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   []*advertisementConfig
+		toAdd     *advertisementConfig
+		expected  []*advertisementConfig
+		shouldErr bool
+	}{
+		{
+			name:    "starting empty",
+			current: []*advertisementConfig{},
+			toAdd: &advertisementConfig{
+				Prefix:   "192.168.1.1/32",
+				IPFamily: ipfamily.IPv4,
+			},
+			expected: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+		},
+		{
+			name: "mismatch localpref",
+			current: []*advertisementConfig{{
+				Prefix:    "192.168.1.1/32",
+				IPFamily:  ipfamily.IPv4,
+				LocalPref: uint32(12),
+			}},
+			toAdd: &advertisementConfig{
+				Prefix:    "192.168.1.1/32",
+				IPFamily:  ipfamily.IPv4,
+				LocalPref: uint32(13),
+			},
+			shouldErr: true,
+		},
+		{
+			name: "adding to back",
+			current: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+			toAdd: &advertisementConfig{
+				Prefix:   "192.168.1.2/32",
+				IPFamily: ipfamily.IPv4,
+			},
+			expected: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.2/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+		},
+		{
+			name: "adding to head",
+			current: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.2/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+			toAdd: &advertisementConfig{
+				Prefix:   "192.168.1.1/32",
+				IPFamily: ipfamily.IPv4,
+			},
+			expected: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.2/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+		},
+		{
+			name: "adding in the middle",
+			current: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.3/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+			toAdd: &advertisementConfig{
+				Prefix:   "192.168.1.2/32",
+				IPFamily: ipfamily.IPv4,
+			},
+			expected: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.2/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.3/32",
+					IPFamily: ipfamily.IPv4,
+				},
+			},
+		},
+		{
+			name: "should add communities",
+			current: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.3/32",
+					IPFamily: ipfamily.IPv4,
+					Communities: []string{
+						"1111:2222",
+						"3333:4444",
+					},
+				},
+			},
+			toAdd: &advertisementConfig{
+				Prefix:   "192.168.1.3/32",
+				IPFamily: ipfamily.IPv4,
+				Communities: []string{
+					"1111:2222",
+					"5555:6666",
+				},
+			},
+			expected: []*advertisementConfig{
+				{
+					Prefix:   "192.168.1.1/32",
+					IPFamily: ipfamily.IPv4,
+				},
+				{
+					Prefix:   "192.168.1.3/32",
+					IPFamily: ipfamily.IPv4,
+					Communities: []string{
+						"1111:2222",
+						"3333:4444",
+						"5555:6666",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := addToAdvertisements(tt.current, tt.toAdd)
+			if err != nil && !tt.shouldErr {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if err == nil && tt.shouldErr {
+				t.Fatalf("expecting error")
+			}
+			if !reflect.DeepEqual(res, tt.expected) {
+				t.Fatalf("expecting %s got %s", spew.Sdump(tt.expected), spew.Sdump(res))
+			}
+		})
+	}
 }

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
@@ -1,0 +1,49 @@
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+


### PR DESCRIPTION
Passing multiple advertisements with the same prefix to the template causes duplicate entries. This happens for example when the shared ip annotation is used with the services.

Since a given advertisement has the related peers as fields, the right place to squash is when we manage the advertisements related to a given neighbor.
