### PR TITLE
OCPBUGS-33936: FRR: squash advertisements with the same prefix

### DIFF
--- a/internal/bgp/frr/frr.go
+++ b/internal/bgp/frr/frr.go
@@ -18,6 +18,7 @@ import (
 	metallbconfig "go.universe.tf/metallb/internal/config"
 	"go.universe.tf/metallb/internal/ipfamily"
 	"go.universe.tf/metallb/internal/logging"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // As the MetalLB controller should handle messages synchronously, there should
@@ -287,9 +288,6 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 			rout.neighbors[neighborName] = neighbor
 		}
 
-		/* As 'session.advertised' is a map, we can be sure there are no
-		   duplicate prefixes and can, therefore, just add them to the
-		   'neighbor.Advertisements' list. */
 		for _, adv := range s.advertised {
 			if !adv.MatchesPeer(s.name) {
 				continue
@@ -313,7 +311,11 @@ func (sm *sessionManager) createConfig() (*frrConfig, error) {
 				LocalPref:   adv.LocalPref,
 			}
 
-			neighbor.Advertisements = append(neighbor.Advertisements, &advConfig)
+			neighbor.Advertisements, err = addToAdvertisements(neighbor.Advertisements, &advConfig)
+			if err != nil {
+				return nil, err
+			}
+
 			switch family {
 			case ipfamily.IPv4:
 				rout.ipV4Prefixes[prefix] = prefix
@@ -447,4 +449,51 @@ func sortMap[T any](toSort map[string]T) []T {
 		res = append(res, toSort[k])
 	}
 	return res
+}
+
+func addToAdvertisements(current []*advertisementConfig, toAdd *advertisementConfig) ([]*advertisementConfig, error) {
+	i := sort.Search(len(current), func(i int) bool { return current[i].Prefix >= toAdd.Prefix })
+	if i == len(current) {
+		return append(current, toAdd), nil
+	}
+
+	if current[i].Prefix == toAdd.Prefix {
+		var err error
+		current[i], err = mergeAdvertisements(current[i], toAdd)
+		if err != nil {
+			return nil, err
+		}
+		return current, nil
+	}
+	res := make([]*advertisementConfig, len(current)+1)
+	copy(res[:i], current[:i])
+	copy(res[i+1:], current[i:])
+	res[i] = toAdd
+	return res, nil
+}
+
+func mergeAdvertisements(adv1, adv2 *advertisementConfig) (*advertisementConfig, error) {
+	res := &advertisementConfig{}
+	if adv1.Prefix != adv2.Prefix {
+		return nil, fmt.Errorf("cannot merge advertisements with different prefixes: %s != %s", adv1.Prefix, adv2.Prefix)
+	}
+	if adv1.IPFamily != adv2.IPFamily {
+		return nil, fmt.Errorf("cannot merge advertisements with different ipfamilies: %s != %s", adv1.IPFamily, adv2.IPFamily)
+	}
+	if adv1.LocalPref != adv2.LocalPref {
+		return nil, fmt.Errorf("cannot merge advertisements with different local preferences: %d != %d", adv1.LocalPref, adv2.LocalPref)
+	}
+
+	res.Prefix = adv1.Prefix
+	res.IPFamily = adv1.IPFamily
+	res.LocalPref = adv1.LocalPref
+	res.Communities = mergeCommunities(adv1.Communities, adv2.Communities)
+	return res, nil
+}
+
+func mergeCommunities(c1, c2 []string) []string {
+	communities := sets.String{}
+	communities.Insert(c1...)
+	communities.Insert(c2...)
+	return communities.List()
 }

--- a/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
+++ b/internal/bgp/frr/testdata/TestTwoAdvertisementsDuplicate.golden
@@ -1,0 +1,49 @@
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+route-map 10.2.2.254-in deny 20
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 1 permit 172.16.1.10/24
+
+route-map 10.2.2.254-out permit 1
+  match ip address prefix-list 10.2.2.254-pl-ipv4
+route-map 10.2.2.254-out permit 2
+  match ipv6 address prefix-list 10.2.2.254-pl-ipv4
+
+
+
+ip prefix-list 10.2.2.254-pl-ipv4 seq 2 deny any
+ipv6 prefix-list 10.2.2.254-pl-ipv4 seq 3 deny any
+
+router bgp 100
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+
+  bgp router-id 10.1.1.254
+  neighbor 10.2.2.254 remote-as 200
+  neighbor 10.2.2.254 ebgp-multihop
+  neighbor 10.2.2.254 port 179
+  neighbor 10.2.2.254 timers 1 1
+  neighbor 10.2.2.254 password password
+  neighbor 10.2.2.254 update-source 10.1.1.254
+
+  address-family ipv4 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 10.2.2.254 activate
+    neighbor 10.2.2.254 route-map 10.2.2.254-in in
+    neighbor 10.2.2.254 route-map 10.2.2.254-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 172.16.1.10/24
+  exit-address-family
+
+


### PR DESCRIPTION
Passing multiple advertisements with the same prefix to the template
causes duplicate entries. This happens for example when the shared ip
annotation is used with the services.

Since a given advertisement has the related peers as fields, the right
place to squash is when we manage the advertisements related to a given
neighbor.

non clean backport of https://github.com/openshift/metallb/pull/174