### PR TITLE
OCPBUGS-31832: Improve error message when keepalivetime is invalid

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -394,7 +394,8 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 
 	// keepalive must be lower than holdtime
 	if keepaliveTime > holdTime {
-		return nil, fmt.Errorf("invalid keepaliveTime %q", p.Spec.KeepaliveTime)
+		return nil, fmt.Errorf("invalid keepaliveTime %q must be smaller than holdtime %q",
+			keepaliveTime, holdTime)
 	}
 
 	// Ideally we would set a default RouterID here, instead of having

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -725,6 +725,36 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid keepalivetime larger than default holdtime",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:         42,
+							ASN:           42,
+							Address:       "1.2.3.4",
+							KeepaliveTime: metav1.Duration{Duration: 91 * time.Second}},
+					},
+				},
+			},
+		},
+		{
+			desc: "invalid keepalivetime larger than holdtime",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:         42,
+							ASN:           42,
+							Address:       "1.2.3.4",
+							HoldTime:      metav1.Duration{Duration: 30 * time.Second},
+							KeepaliveTime: metav1.Duration{Duration: 90 * time.Second}},
+					},
+				},
+			},
+		},
+
+		{
 			desc: "invalid hold time (too short)",
 			crs: ClusterResources{
 				Peers: []v1beta2.BGPPeer{


### PR DESCRIPTION
and extend unit-tests for that case

/kind bug
