### PR TITLE
OCPBUGS-35864: ci: fix registry auth error

### DIFF
--- a/openshift-ci/metallb-operator-deploy/build_and_push_index.sh
+++ b/openshift-ci/metallb-operator-deploy/build_and_push_index.sh
@@ -6,8 +6,12 @@ cd /tmp/metallb-operator-deploy
 wget -q https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/linux-amd64-opm
 mv linux-amd64-opm opm
 chmod +x ./opm
-export pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".password /var/run/secrets/openshift.io/push/.dockercfg )
-podman login -u serviceaccount -p "${pass:1:-1}" image-registry.openshift-image-registry.svc:5000 --tls-verify=false
+
+set +x
+pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".auth /var/run/secrets/openshift.io/push/.dockercfg )
+pass=`echo ${pass:1:-1} | base64 -d`
+podman login -u serviceaccount -p ${pass:8} image-registry.openshift-image-registry.svc:5000 --tls-verify=false
+set -x
 
 podman build -f bundleci.Dockerfile --tag image-registry.openshift-image-registry.svc:5000/openshift-marketplace/metallboperatorbundle:latest .
 podman push image-registry.openshift-image-registry.svc:5000/openshift-marketplace/metallboperatorbundle:latest --tls-verify=false


### PR DESCRIPTION
because openshift-ci is failing with hidden error
```
Error: logging into "image-registry.openshift-image-registry.svc:5000": invalid username/password
```
and buildindeximage pod to status ImagePullBackOff
