### PR TITLE
CI: explicitly set frr when running with frr as backend

### DIFF
--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -149,6 +149,7 @@ metadata:
   namespace: metallb-system
 spec:
   logLevel: debug
+  bgpBackend: frr
 EOF
 fi
 


### PR DESCRIPTION
We are moving the default to frr-k8s, so for the time being we set explicitly the backend to frr in case of frr jobs, otherwise we might incur in the scenario where the tests think it's frr while the deployment is frr-k8s based.

Needed to fix the failures in https://github.com/openshift/metallb-operator/pull/231