### PR TITLE
OpenshiftCI: unset the frr-k8s backend on the frr-k8s lane

### DIFF
--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -146,7 +146,6 @@ metadata:
   namespace: metallb-system
 spec:
   logLevel: debug
-  bgpBackend: frr-k8s
 EOF
 else
 oc apply -f - <<EOF


### PR DESCRIPTION
Now that it's the default we can unset it.
