### PR TITLE
Openshift CI: run frr-k8s e2e tests

### DIFF
--- a/openshift-ci/enable_frrk8s_on_cno.sh
+++ b/openshift-ci/enable_frrk8s_on_cno.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# this script enables the cluster to deploy frrk8s via CNO and waits 
+# for the cluster to be stable
+set -euo pipefail
+
+
+oc patch featuregate cluster --type json  -p '[{"op": "add", "path": "/spec/featureSet", "value": TechPreviewNoUpgrade}]'
+
+echo "waiting for the additionalRouting field to be available"
+
+end=$((SECONDS+600))
+while ! oc get crds networks.operator.openshift.io -o yaml | grep -q "additionalRouting" && [[ ${SECONDS} -lt ${end} ]]; do
+    sleep 1
+done
+
+if ! oc get crds networks.operator.openshift.io -o yaml | grep -i "additionalRouting"; then
+	echo "additionalRouting field was never available"
+	exit 1
+fi
+
+echo "additionalRouting field is available"
+
+echo "waiting for the mcps to start Upgrading"
+
+oc wait --for=condition=Updating=True mcp master --timeout=30m
+oc wait --for=condition=Updating=True mcp worker --timeout=30m
+
+echo "waiting for the mcps to be updated"
+
+oc wait --for=condition=Updated=True mcp master --timeout=30m
+oc wait --for=condition=Updated=True mcp worker --timeout=30m
+
+echo "mcps are updated"
+

--- a/openshift-ci/run_e2e.sh
+++ b/openshift-ci/run_e2e.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 metallb_dir="$(dirname $(readlink -f $0))"
 source ${metallb_dir}/common.sh
 
-METALLB_REPO=${METALLB_REPO:-"https://github.com/openshift/metallb.git"}
 BGP_TYPE=${BGP_TYPE:-""}
 IP_STACK=${IP_STACK:-""}
+RUN_FRR_K8S_TESTS=${RUN_FRR_K8S_TESTS:-""}
+
 
 # add firewalld rules
 sudo firewall-cmd --zone=libvirt --permanent --add-port=179/tcp
@@ -23,64 +24,13 @@ sudo firewall-cmd --zone=libvirt --add-port=3785/udp
 sudo firewall-cmd --zone=libvirt --permanent --add-port=4784/udp
 sudo firewall-cmd --zone=libvirt --add-port=4784/udp
 
-if [[ "$BGP_TYPE" == "frr-k8s" || "$BGP_TYPE" == "frr-k8s-cno" ]]; then
-	MODE_TO_SKIP="FRR-MODE"
-	BGP_MODE="frr-k8s"
+export REPORTER_PATH=/logs/artifacts/
+mkdir -p $REPORTER_PATH
+
+go install github.com/onsi/ginkgo/v2/ginkgo@v2.20.2
+
+if [[ "$RUN_FRR_K8S_TESTS" == "true" ]]; then
+	${metallb_dir}/run_frrk8s_e2e.sh $BGP_TYPE $IP_STACK
 else
-	MODE_TO_SKIP="FRRK8S-MODE"
-	BGP_MODE="frr"
+	${metallb_dir}/run_metallb_e2e.sh $BGP_TYPE $IP_STACK
 fi
-
-FRRK8S_NAMESPACE=""
-if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
-  FRRK8S_NAMESPACE="--frr-k8s-namespace=openshift-frr-k8s"
-fi
-
-# need to skip L2 metrics / node selector test because the pod that's running the tests is not
-# same subnet of the cluster nodes, so the arp request that's done in the test won't work.
-# Also, skip l2 interface selector as it's not supported d/s currently.
-# Skip route injection after setting up speaker. FRR is not refreshed.
-
-SKIP="L2 Cordon|L2 metrics|L2 Node Selector|L2-interface selector|L2ServiceStatus|NetworkUnavailable|NodeExcludeBalancers|$MODE_TO_SKIP"
-
-if [ "${IP_STACK}" = "v4" ]; then
-	SKIP="$SKIP|IPV6|DUALSTACK"
-	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
-	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
-elif [ "${IP_STACK}" = "v6" ]; then
-	SKIP="$SKIP|IPV4|DUALSTACK"
-	export PROVISIONING_HOST_EXTERNAL_IPV6=${PROVISIONING_HOST_EXTERNAL_IP}
-	export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
-elif [ "${IP_STACK}" = "v4v6" ]; then
-	SKIP="$SKIP|IPV6"
-	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
-	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
-fi
-echo "Skipping ${SKIP}"
-
-# Let's enforce failing when running the tests
-set -e
-
-pip3 install --user -r ./../dev-env/requirements.txt
-# Install ginkgo CLI.
-go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0
-export PATH=${PATH}:${HOME}/.local/bin
-export CONTAINER_RUNTIME=podman
-export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
-inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
-	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
-	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--prometheus-namespace="openshift-monitoring" \
-	--local-nics="_" --node-nics="_" --skip="${SKIP}" --external-frr-image="quay.io/frrouting/frr:8.3.1" \
-	--bgp-mode="$BGP_MODE" $FRRK8S_NAMESPACE
-
-oc wait --for=delete namespace/metallb-system-other --timeout=2m || true # making sure the namespace is deleted (should happen in aftersuite)
-
-FOCUS_EBGP="BGP A service of protocol load balancer should work with ETP=cluster IPV4" # Just a smoke test to make sure ebgp works
-
-inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
-	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
-	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
-	--prometheus-namespace="openshift-monitoring" \
-	--local-nics="_" --node-nics="_" --focus="${FOCUS_EBGP}" --external-frr-image="quay.io/frrouting/frr:8.3.1" \
-	--host-bgp-mode="ebgp" --bgp-mode="$BGP_MODE" $FRRK8S_NAMESPACE

--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+BGP_TYPE=$1
+IP_STACK=$2
+
+FRRK8S_DIR="$(dirname $(readlink -f $0))/../../frr"
+
+KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
+pushd $FRRK8S_DIR
+
+SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips"
+SKIP="$SKIP\|should.*block.*always.*block.*cidr"
+
+if [[ "$BGP_TYPE" == "frr-k8s" ]]; then
+  SKIP="$SKIP\|metrics"  # because when running as a metallb pod the metrics are overridden.
+fi
+
+FRRK8S_NAMESPACE="metallb-system"
+if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
+  FRRK8S_NAMESPACE="openshift-frr-k8s"
+fi
+
+if [ "${IP_STACK}" = "v4" ]; then
+	SKIP="$SKIP\|IPV6\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+elif [ "${IP_STACK}" = "v6" ]; then
+	SKIP="$SKIP\|IPV4\|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV6=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
+elif [ "${IP_STACK}" = "v4v6" ]; then
+	SKIP="$SKIP\|IPV6"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+fi
+echo "Skipping ${SKIP}"
+
+## In order to make the VRF leaking tests work we need to
+pods=$(oc get pods -l "app=frr-k8s" -n $FRRK8S_NAMESPACE -o jsonpath='{.items[*].metadata.name}')
+
+echo "creating vrfs in pods $pods"
+for pod in $pods; do
+  echo "creating vrf in pod $pod"
+  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link add red type vrf table 1100
+  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link set red up
+done
+
+export TEST_ARGS="--frr-k8s-namespace=$FRRK8S_NAMESPACE --kubeconfig=$KUBECONFIG --prometheus-namespace=openshift-monitoring --report-path=$REPORTER_PATH"
+
+export RUN_FRR_CONTAINER_ON_HOST_NETWORK="true"
+
+make ginkgo
+make kubectl
+KUBECONFIG_PATH="$KUBECONFIG" GINKGO_ARGS="--skip $SKIP" make e2etests
+
+popd

--- a/openshift-ci/run_metallb_e2e.sh
+++ b/openshift-ci/run_metallb_e2e.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+BGP_TYPE=$1
+IP_STACK=$2
+
+if [[ "$BGP_TYPE" == "frr-k8s" || "$BGP_TYPE" == "frr-k8s-cno" ]]; then
+	MODE_TO_SKIP="FRR-MODE"
+	BGP_MODE="frr-k8s"
+else
+	MODE_TO_SKIP="FRRK8S-MODE"
+	BGP_MODE="frr"
+fi
+# need to skip L2 metrics / node selector test because the pod that's running the tests is not
+# same subnet of the cluster nodes, so the arp request that's done in the test won't work.
+# Also, skip l2 interface selector as it's not supported d/s currently.
+# Skip route injection after setting up speaker. FRR is not refreshed.
+
+SKIP="L2 Cordon|L2 metrics|L2 Node Selector|L2-interface selector|L2ServiceStatus|NetworkUnavailable|NodeExcludeBalancers|$MODE_TO_SKIP"
+
+if [ "${IP_STACK}" = "v4" ]; then
+	SKIP="$SKIP|IPV6|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+elif [ "${IP_STACK}" = "v6" ]; then
+	SKIP="$SKIP|IPV4|DUALSTACK"
+	export PROVISIONING_HOST_EXTERNAL_IPV6=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV4=1.1.1.1
+elif [ "${IP_STACK}" = "v4v6" ]; then
+	SKIP="$SKIP|IPV6"
+	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
+	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+fi
+echo "Skipping ${SKIP}"
+
+# Let's enforce failing when running the tests
+set -e
+
+pip3 install --user -r ./../dev-env/requirements.txt
+
+FRRK8S_NAMESPACE=""
+if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
+  FRRK8S_NAMESPACE="--frr-k8s-namespace=openshift-frr-k8s"
+fi
+
+# Install ginkgo CLI.
+export PATH=${PATH}:${HOME}/.local/bin
+export CONTAINER_RUNTIME=podman
+export RUN_FRR_CONTAINER_ON_HOST_NETWORK=true
+
+mkdir -p /tmp/report
+inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
+	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
+	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
+	--prometheus-namespace="openshift-monitoring" \
+	--local-nics="_" --node-nics="_" --skip="${SKIP}" --external-frr-image="quay.io/frrouting/frr:8.3.1" \
+	--bgp-mode="$BGP_MODE" $FRRK8S_NAMESPACE 
+
+cp -r /tmp/report $REPORTER_PATH
+
+oc wait --for=delete namespace/metallb-system-other --timeout=2m || true # making sure the namespace is deleted (should happen in aftersuite)
+
+FOCUS_EBGP="BGP A service of protocol load balancer should work with ETP=cluster IPV4" # Just a smoke test to make sure ebgp works
+
+inv e2etest --kubeconfig=$(readlink -f ../../ocp/ostest/auth/kubeconfig) \
+	--service-pod-port=8080 --system-namespaces="metallb-system" --skip-docker \
+	--ipv4-service-range=192.168.10.0/24 --ipv6-service-range=fc00:f853:0ccd:e799::/124 \
+	--prometheus-namespace="openshift-monitoring" \
+	--local-nics="_" --node-nics="_" --focus="${FOCUS_EBGP}" --external-frr-image="quay.io/frrouting/frr:8.3.1" \
+	--host-bgp-mode="ebgp" --bgp-mode="$BGP_MODE" $FRRK8S_NAMESPACE


### PR DESCRIPTION
Running frrk8s e2e tests to make sure we don't regress.

Note: despite the fact that this PR won't execute the frr tests in the latest version, it was tested by forcing the execution of the tests here https://github.com/openshift/metallb/pull/198/files#diff-e2ff966b1775ad5e6d156754f37e1ae53615a0dfb1ecdd123728f70a1235ae2aR32

Once this merges, new lanes will be defined under frr
