### PR TITLE
OCPBUGS-37295: Sessions flapping when a service is added, backporting

### DIFF
--- a/e2etest/bgptests/bgp.go
+++ b/e2etest/bgptests/bgp.go
@@ -520,6 +520,33 @@ var _ = ginkgo.Describe("BGP", func() {
 				return nil
 			}, 4*time.Minute, 1*time.Second).ShouldNot(HaveOccurred())
 
+			ginkgo.By("checking the sessions don't flap when changing the configuration")
+
+			previousNeighbors := map[string]frr.NeighborsMap{}
+			for _, c := range FRRContainers {
+				neighbors, err := frr.NeighborsInfo(c)
+				Expect(err).NotTo(HaveOccurred())
+				previousNeighbors[c.Name] = neighbors
+			}
+			ginkgo.By("creating another the service")
+			svc1, _ := testservice.CreateWithBackend(cs, f.Namespace.Name, "external-local-lb1", tweak)
+			defer testservice.Delete(cs, svc1)
+
+			Consistently(func() error {
+				for _, c := range FRRContainers {
+					neighbors, err := frr.NeighborsInfo(c)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(neighbors).To(HaveLen(len(previousNeighbors[c.Name])))
+
+					for _, n := range neighbors {
+						previousDropped := previousNeighbors[c.Name][n.IP.String()].ConnectionsDropped
+						if n.ConnectionsDropped > previousDropped {
+							return fmt.Errorf("increased connections dropped from %s to %s, previous: %d current %d", c.Name, n.IP.String(), previousDropped, n.ConnectionsDropped)
+						}
+					}
+				}
+				return nil
+			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		},
 			ginkgo.Entry("IPV4 - default",
 				metallbv1beta1.BFDProfile{

--- a/e2etest/pkg/frr/bgp.go
+++ b/e2etest/pkg/frr/bgp.go
@@ -31,18 +31,24 @@ func NeighborInfo(neighborName string, exec executor.Executor) (*Neighbor, error
 	return neighbor, nil
 }
 
-// NeighborsForContainer returns informations for the all the neighbors in the given
+type NeighborsMap map[string]*Neighbor
+
+// NeighborsInfo returns informations for the all the neighbors in the given
 // executor.
-func NeighborsInfo(exec executor.Executor) ([]*Neighbor, error) {
-	res, err := exec.Exec("vtysh", "-c", "show bgp neighbor json")
+func NeighborsInfo(exec executor.Executor) (NeighborsMap, error) {
+	jsonRes, err := exec.Exec("vtysh", "-c", "show bgp neighbor json")
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to query neighbours")
 	}
-	neighbors, err := ParseNeighbours(res)
+	neighbors, err := ParseNeighbours(jsonRes)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to parse neighbours %s", res)
+		return nil, errors.Wrapf(err, "Failed to parse neighbours %s", jsonRes)
 	}
-	return neighbors, nil
+	res := map[string]*Neighbor{}
+	for _, n := range neighbors {
+		res[n.IP.String()] = n
+	}
+	return res, nil
 }
 
 // Routes returns informations about routes in the given executor

--- a/e2etest/pkg/frr/parse.go
+++ b/e2etest/pkg/frr/parse.go
@@ -13,15 +13,16 @@ import (
 )
 
 type Neighbor struct {
-	IP             net.IP
-	VRF            string
-	Connected      bool
-	LocalAS        string
-	RemoteAS       string
-	PrefixSent     int
-	Port           int
-	RemoteRouterID string
-	MsgStats       MessageStats
+	IP                 net.IP
+	VRF                string
+	Connected          bool
+	LocalAS            string
+	RemoteAS           string
+	PrefixSent         int
+	Port               int
+	RemoteRouterID     string
+	MsgStats           MessageStats
+	ConnectionsDropped int
 }
 
 type Route struct {
@@ -45,6 +46,7 @@ type FRRNeighbor struct {
 	AddressFamilyInfo map[string]struct {
 		SentPrefixCounter int `json:"sentPrefixCounter"`
 	} `json:"addressFamilyInfo"`
+	ConnectionsDropped int `json:"connectionsDropped"`
 }
 
 type MessageStats struct {
@@ -128,14 +130,15 @@ func ParseNeighbour(vtyshRes string) (*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		return &Neighbor{
-			IP:             ip,
-			Connected:      connected,
-			LocalAS:        strconv.Itoa(n.LocalAs),
-			RemoteAS:       strconv.Itoa(n.RemoteAs),
-			PrefixSent:     prefixSent,
-			Port:           n.PortForeign,
-			RemoteRouterID: n.RemoteRouterID,
-			MsgStats:       n.MsgStats,
+			IP:                 ip,
+			Connected:          connected,
+			LocalAS:            strconv.Itoa(n.LocalAs),
+			RemoteAS:           strconv.Itoa(n.RemoteAs),
+			PrefixSent:         prefixSent,
+			Port:               n.PortForeign,
+			RemoteRouterID:     n.RemoteRouterID,
+			MsgStats:           n.MsgStats,
+			ConnectionsDropped: n.ConnectionsDropped,
 		}, nil
 	}
 	return nil, errors.New("no peers were returned")
@@ -165,14 +168,15 @@ func ParseNeighbours(vtyshRes string) ([]*Neighbor, error) {
 			prefixSent += s.SentPrefixCounter
 		}
 		res = append(res, &Neighbor{
-			IP:             ip,
-			Connected:      connected,
-			LocalAS:        strconv.Itoa(n.LocalAs),
-			RemoteAS:       strconv.Itoa(n.RemoteAs),
-			PrefixSent:     prefixSent,
-			Port:           n.PortForeign,
-			RemoteRouterID: n.RemoteRouterID,
-			MsgStats:       n.MsgStats,
+			IP:                 ip,
+			Connected:          connected,
+			LocalAS:            strconv.Itoa(n.LocalAs),
+			RemoteAS:           strconv.Itoa(n.RemoteAs),
+			PrefixSent:         prefixSent,
+			Port:               n.PortForeign,
+			RemoteRouterID:     n.RemoteRouterID,
+			MsgStats:           n.MsgStats,
+			ConnectionsDropped: n.ConnectionsDropped,
 		})
 	}
 	return res, nil

--- a/e2etest/pkg/frr/validation.go
+++ b/e2etest/pkg/frr/validation.go
@@ -15,7 +15,7 @@ import (
 // frr instance. We only care about established connections, as the
 // frr instance may be configured with more nodes than are currently
 // paired.
-func NeighborsMatchNodes(nodes []v1.Node, neighbors []*Neighbor, ipFamily ipfamily.Family, vrfName string) error {
+func NeighborsMatchNodes(nodes []v1.Node, neighbors NeighborsMap, ipFamily ipfamily.Family, vrfName string) error {
 	nodesIPs := map[string]struct{}{}
 
 	ips, err := k8s.NodeIPsForFamily(nodes, ipFamily, vrfName)

--- a/internal/bgp/frr/templates/neighborsession.tmpl
+++ b/internal/bgp/frr/templates/neighborsession.tmpl
@@ -14,6 +14,7 @@
   neighbor {{.neighbor.Addr}} update-source {{.neighbor.SrcAddr}}
   {{- end }}
 {{- if ne .neighbor.BFDProfile ""}}
+  neighbor {{.neighbor.Addr}} bfd
   neighbor {{.neighbor.Addr}} bfd profile {{.neighbor.BFDProfile}}
 {{- end }}
 {{- if  mustDisableConnectedCheck .neighbor.IPFamily .routerASN .neighbor.ASN .neighbor.EBGPMultiHop }}

--- a/internal/bgp/frr/testdata/TestBFDWithSession.golden
+++ b/internal/bgp/frr/testdata/TestBFDWithSession.golden
@@ -26,6 +26,7 @@ router bgp 100
   neighbor 10.2.2.254 timers 2 1
   neighbor 10.2.2.254 password password
   neighbor 10.2.2.254 update-source 10.1.1.254
+  neighbor 10.2.2.254 bfd
   neighbor 10.2.2.254 bfd profile foo
 
   address-family ipv4 unicast


### PR DESCRIPTION
Backporting the fix and the tests