### PR TITLE
OCPBUGS-25783: D/S only: fix the frr path used by tests

### DIFF
--- a/e2etest/pkg/frr/container/container.go
+++ b/e2etest/pkg/frr/container/container.go
@@ -28,7 +28,7 @@ const (
 	// BGP configuration directory.
 	frrConfigDir = "config/frr"
 	// FRR routing image.
-	frrImage = "frrouting/frr:v7.5.1"
+	frrImage = "docker.io/frrouting/frr:v7.5.1"
 	// Host network name.
 	hostNetwork = "host"
 	// FRR container mount destination path.


### PR DESCRIPTION
Trying to fix the
"Error: short-name resolution enforced but cannot prompt without a TTY" we are getting in CI.
