### PR TITLE
OCPBUGS-44730: Metrics: add ipv4/6 addresses_in_use_total and addresses_total

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -27,6 +27,8 @@ type Allocator struct {
 	portsInUse      map[string]map[Port]string // ip.String() -> Port -> svc
 	servicesOnIP    map[string]map[string]bool // ip.String() -> svc -> allocated?
 	poolIPsInUse    map[string]map[string]int  // poolName -> ip.String() -> number of users
+	poolIPV4InUse   map[string]map[string]int  // poolName -> ipv4.String() -> number of users
+	poolIPV6InUse   map[string]map[string]int  // poolName -> ipv6.String() -> number of users
 }
 
 // Port represents one port in use by a service.
@@ -62,6 +64,8 @@ func New() *Allocator {
 		portsInUse:      map[string]map[Port]string{},
 		servicesOnIP:    map[string]map[string]bool{},
 		poolIPsInUse:    map[string]map[string]int{},
+		poolIPV4InUse:   map[string]map[string]int{},
+		poolIPV6InUse:   map[string]map[string]int{},
 	}
 }
 
@@ -105,8 +109,13 @@ func (a *Allocator) SetPools(pools *config.Pools) error {
 
 	// Refresh or initiate stats
 	for n, p := range a.pools.ByName {
-		stats.poolCapacity.WithLabelValues(n).Set(float64(poolCount(p)))
+		total, ipv4, ipv6 := poolCount(p)
+		stats.poolCapacity.WithLabelValues(n).Set(float64(total))
+		stats.ipv4PoolCapacity.WithLabelValues(n).Set(float64(ipv4))
+		stats.ipv6PoolCapacity.WithLabelValues(n).Set(float64(ipv6))
 		stats.poolActive.WithLabelValues(n).Set(float64(len(a.poolIPsInUse[n])))
+		stats.ipv4PoolActive.WithLabelValues(n).Set(float64(len(a.poolIPV4InUse[n])))
+		stats.ipv6PoolActive.WithLabelValues(n).Set(float64(len(a.poolIPV6InUse[n])))
 	}
 
 	return nil
@@ -132,10 +141,27 @@ func (a *Allocator) assign(svc string, alloc *alloc) {
 		if a.poolIPsInUse[alloc.pool] == nil {
 			a.poolIPsInUse[alloc.pool] = map[string]int{}
 		}
+		if a.poolIPV4InUse[alloc.pool] == nil {
+			a.poolIPV4InUse[alloc.pool] = map[string]int{}
+		}
+		if a.poolIPV6InUse[alloc.pool] == nil {
+			a.poolIPV6InUse[alloc.pool] = map[string]int{}
+		}
+
 		a.poolIPsInUse[alloc.pool][ip.String()]++
+		if ip.To4() == nil {
+			a.poolIPV6InUse[alloc.pool][ip.String()]++
+		} else {
+			a.poolIPV4InUse[alloc.pool][ip.String()]++
+		}
 	}
-	stats.poolCapacity.WithLabelValues(alloc.pool).Set(float64(poolCount(a.pools.ByName[alloc.pool])))
+	total, ipv4, ipv6 := poolCount(a.pools.ByName[alloc.pool])
+	stats.poolCapacity.WithLabelValues(alloc.pool).Set(float64(total))
+	stats.ipv4PoolCapacity.WithLabelValues(alloc.pool).Set(float64(ipv4))
+	stats.ipv6PoolCapacity.WithLabelValues(alloc.pool).Set(float64(ipv6))
 	stats.poolActive.WithLabelValues(alloc.pool).Set(float64(len(a.poolIPsInUse[alloc.pool])))
+	stats.ipv4PoolActive.WithLabelValues(alloc.pool).Set(float64(len(a.poolIPV4InUse[alloc.pool])))
+	stats.ipv6PoolActive.WithLabelValues(alloc.pool).Set(float64(len(a.poolIPV6InUse[alloc.pool])))
 }
 
 // Assign assigns the requested ip to svc, if the assignment is
@@ -209,13 +235,26 @@ func (a *Allocator) Unassign(svc string) {
 			delete(a.sharingKeyForIP, ip.String())
 		}
 		a.poolIPsInUse[al.pool][ip.String()]--
+		if ip.To4() == nil {
+			a.poolIPV6InUse[al.pool][ip.String()]--
+		} else {
+			a.poolIPV4InUse[al.pool][ip.String()]--
+		}
+		// Explicitly delete unused IPs from the pool, so that len()
+		// is an accurate count of IPs in use.
 		if a.poolIPsInUse[al.pool][ip.String()] == 0 {
-			// Explicitly delete unused IPs from the pool, so that len()
-			// is an accurate count of IPs in use.
 			delete(a.poolIPsInUse[al.pool], ip.String())
+		}
+		if a.poolIPV4InUse[al.pool][ip.String()] == 0 {
+			delete(a.poolIPV4InUse[al.pool], ip.String())
+		}
+		if a.poolIPV6InUse[al.pool][ip.String()] == 0 {
+			delete(a.poolIPV6InUse[al.pool], ip.String())
 		}
 	}
 	stats.poolActive.WithLabelValues(al.pool).Set(float64(len(a.poolIPsInUse[al.pool])))
+	stats.ipv4PoolActive.WithLabelValues(al.pool).Set(float64(len(a.poolIPV4InUse[al.pool])))
+	stats.ipv6PoolActive.WithLabelValues(al.pool).Set(float64(len(a.poolIPV6InUse[al.pool])))
 }
 
 // AllocateFromPool assigns an available IP from pool to service.
@@ -390,14 +429,17 @@ func sharingOK(existing, new *key) error {
 }
 
 // poolCount returns the number of addresses in the pool.
-func poolCount(p *config.Pool) int64 {
+func poolCount(p *config.Pool) (int64, int64, int64) {
 	var total int64
+	var ipv4 int64
+	var ipv6 int64
 	for _, cidr := range p.CIDR {
 		o, b := cidr.Mask.Size()
 		if b-o >= 62 {
 			// An enormous ipv6 range is allocated which will never run out.
-			// Just return max to avoid any math errors.
-			return math.MaxInt64
+			total = math.MaxInt64
+			ipv6 = math.MaxInt64
+			continue
 		}
 		sz := int64(math.Pow(2, float64(b-o)))
 
@@ -423,8 +465,13 @@ func poolCount(p *config.Pool) int64 {
 			}
 		}
 		total += sz
+		if cidr.IP.To4() == nil {
+			ipv6 += sz
+		} else {
+			ipv4 += sz
+		}
 	}
-	return total
+	return total, ipv4, ipv6
 }
 
 // poolFor returns the pool that owns the requested IPs, or "" if none.

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1945,6 +1945,8 @@ func TestPoolCount(t *testing.T) {
 		desc string
 		pool *config.Pool
 		want int64
+		ipv4 int64
+		ipv6 int64
 	}{
 		{
 			desc: "BGP /24",
@@ -1952,6 +1954,8 @@ func TestPoolCount(t *testing.T) {
 				CIDR: []*net.IPNet{ipnet("1.2.3.0/24")},
 			},
 			want: 256,
+			ipv4: 256,
+			ipv6: 0,
 		},
 		{
 			desc: "BGP /24 and /25",
@@ -1959,6 +1963,8 @@ func TestPoolCount(t *testing.T) {
 				CIDR: []*net.IPNet{ipnet("1.2.3.0/24"), ipnet("2.3.4.128/25")},
 			},
 			want: 384,
+			ipv4: 384,
+			ipv6: 0,
 		},
 		{
 			desc: "BGP /24 and /25, no buggy IPs",
@@ -1967,6 +1973,8 @@ func TestPoolCount(t *testing.T) {
 				AvoidBuggyIPs: true,
 			},
 			want: 381,
+			ipv4: 381,
+			ipv6: 0,
 		},
 		{
 			desc: "BGP a BIG ipv6 range",
@@ -1975,13 +1983,31 @@ func TestPoolCount(t *testing.T) {
 				AvoidBuggyIPs: true,
 			},
 			want: math.MaxInt64,
+			ipv4: 381,
+			ipv6: math.MaxInt64,
+		},
+		{
+			desc: "ipv4 and ipv6 range",
+			pool: &config.Pool{
+				CIDR:          []*net.IPNet{ipnet("1.2.3.0/31"), ipnet("1000::/127")},
+				AvoidBuggyIPs: true,
+			},
+			want: 3,
+			ipv4: 1,
+			ipv6: 2,
 		},
 	}
 
 	for _, test := range tests {
-		got := poolCount(test.pool)
-		if test.want != got {
-			t.Errorf("%q: wrong pool count, want %d, got %d", test.desc, test.want, got)
+		total, ipv4, ipv6 := poolCount(test.pool)
+		if test.want != total {
+			t.Errorf("%q: wrong pool total count, want %d, got %d", test.desc, test.want, total)
+		}
+		if test.ipv4 != ipv4 {
+			t.Errorf("%q: wrong pool ipv4 count, want %d, got %d", test.desc, test.ipv4, ipv4)
+		}
+		if test.ipv6 != ipv6 {
+			t.Errorf("%q: wrong pool ipv6 count, want %d, got %d", test.desc, test.ipv6, ipv6)
 		}
 	}
 }

--- a/internal/allocator/stats.go
+++ b/internal/allocator/stats.go
@@ -5,9 +5,13 @@ package allocator
 import "github.com/prometheus/client_golang/prometheus"
 
 var stats = struct {
-	poolCapacity  *prometheus.GaugeVec
-	poolActive    *prometheus.GaugeVec
-	poolAllocated *prometheus.GaugeVec
+	poolCapacity     *prometheus.GaugeVec
+	ipv4PoolCapacity *prometheus.GaugeVec
+	ipv6PoolCapacity *prometheus.GaugeVec
+	poolActive       *prometheus.GaugeVec
+	ipv4PoolActive   *prometheus.GaugeVec
+	ipv6PoolActive   *prometheus.GaugeVec
+	poolAllocated    *prometheus.GaugeVec
 }{
 	poolCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "metallb",
@@ -17,11 +21,43 @@ var stats = struct {
 	}, []string{
 		"pool",
 	}),
+	ipv4PoolCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "metallb",
+		Subsystem: "allocator",
+		Name:      "ipv4_addresses_total",
+		Help:      "Number of usable IPV4 addresses, per pool",
+	}, []string{
+		"pool",
+	}),
+	ipv6PoolCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "metallb",
+		Subsystem: "allocator",
+		Name:      "ipv6_addresses_total",
+		Help:      "Number of usable IPV6 addresses, per pool",
+	}, []string{
+		"pool",
+	}),
 	poolActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "metallb",
 		Subsystem: "allocator",
 		Name:      "addresses_in_use_total",
 		Help:      "Number of IP addresses in use, per pool",
+	}, []string{
+		"pool",
+	}),
+	ipv4PoolActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "metallb",
+		Subsystem: "allocator",
+		Name:      "ipv4_addresses_in_use_total",
+		Help:      "Number of IPV4 addresses in use, per pool",
+	}, []string{
+		"pool",
+	}),
+	ipv6PoolActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "metallb",
+		Subsystem: "allocator",
+		Name:      "ipv6_addresses_in_use_total",
+		Help:      "Number of IPV6 addresses in use, per pool",
 	}, []string{
 		"pool",
 	}),
@@ -37,6 +73,10 @@ var stats = struct {
 
 func init() {
 	prometheus.MustRegister(stats.poolCapacity)
+	prometheus.MustRegister(stats.ipv4PoolCapacity)
+	prometheus.MustRegister(stats.ipv6PoolCapacity)
 	prometheus.MustRegister(stats.poolActive)
+	prometheus.MustRegister(stats.ipv4PoolActive)
+	prometheus.MustRegister(stats.ipv6PoolActive)
 	prometheus.MustRegister(stats.poolAllocated)
 }

--- a/website/content/release-notes/_index.md
+++ b/website/content/release-notes/_index.md
@@ -2,6 +2,78 @@
 title: Release Notes
 weight: 8
 ---
+
+## Next release
+
+Chores:
+
+- Enforce adding a release notes entry on each PR ([PR 2191](https://github.com/metallb/metallb/pull/2191))
+- Dev-env: don't run tests against VRFs by default ([PR 2201](https://github.com/metallb/metallb/pull/2201), [ISSUE 2197](https://github.com/metallb/metallb/issues/2197))
+- Dev-env: improve docker build times ([PR 2205](https://github.com/metallb/metallb/pull/2205))
+- Add more frr-k8s related logs under debug loglevel ([PR 2199](https://github.com/metallb/metallb/pull/2199))
+- Move webhooks out of API package ([PR 2193](https://github.com/metallb/metallb/pull/2193))
+- Support running the e2es on frr-k8s deployments ([PR 2180](https://github.com/metallb/metallb/pull/2180))
+- E2E: Receive prefixes using frr-k8s alongside MetalLB ([PR 2211](https://github.com/metallb/metallb/pull/2211))
+- Images updated to Go 1.20.12 ([PR 2213](https://github.com/metallb/metallb/pull/2213))
+- CI/E2E: Relabel the frr metrics from frr-k8s to show as MetalLB's ([PR 2210](https://github.com/metallb/metallb/pull/2210))
+- Dev-env: change the default BGP mode to FRR ([PR 2196](https://github.com/metallb/metallb/pull/2196))
+- Webhooks: avoid transient errors ([PR 2202](https://github.com/metallb/metallb/pull/2202)), [ISSUE 2173](https://github.com/metallb/metallb/issues/2173))
+- Dev-env: Override GOBIN for inv dev-env ([PR 2219](https://github.com/metallb/metallb/pull/2219))
+- Metrics: add ipv4/6 addresses_in_use_total and addresses_total ([PR 2151](https://github.com/metallb/metallb/pull/2151))
+
+## Version 0.13.12
+
+- Change the version of go used to compile the binaries
+- Disable http2 on the webhook listener
+- Bump the kubernetes dependencies
+
+This release includes contributions from Federico Paolinelli, Ori Braunshtein, Micah Nagel
+
+## Version 0.13.11
+
+New features:
+
+- Add namespaces to resources generated using helm templates ([PR 1965](https://github.com/metallb/metallb/pull/1965), [Issue 1964](https://github.com/metallb/metallb/issues/1964))
+- Improve FRR liveness probes configurability in helm charts ([PR 2034](https://github.com/metallb/metallb/pull/2034), [Issue 1963](https://github.com/metallb/metallb/issues/1964)) to make MetalLB's FRR more tolerant to low resources deployments
+- Bump FRR to version to 8.5.2 [PR 2051](https://github.com/metallb/metallb/pull/2051)
+
+Bug Fixes:
+
+- Reprocess all the services only when a pool of IPs changes, and not every time the controller receives it ([PR 1951](https://github.com/metallb/metallb/pull/1951)
+)
+- Delete BFD profiles from the configuration when deleted from CRs ([PR 1973](https://github.com/metallb/metallb/pull/1973))
+- Fix kustomize v5 deprecations ([PR 1986](https://github.com/metallb/metallb/pull/1986), [Issue 1985](https://github.com/metallb/metallb/issues/1985))
+- Make the configuration conversion stable and avoid unnecessary FRR reloads ([PR 1990](https://github.com/metallb/metallb/pull/1990))
+- Change the "interface to exclude" log to debug to avoid spamming logs ([PR 1992](https://github.com/metallb/metallb/pull/1992))
+- Improve the regex excluding well known interfaces from L2 announcement ([PR 2058](https://github.com/metallb/metallb/pull/2058)), [Issue 2057](https://github.com/metallb/metallb/issues/2057)
+
+This release includes contributions from Andreas Lindhé, ankitm123, cyclinder, Federico Paolinelli, Joshua Cooper, Lior Noy, Marcelo Guerrero Viveros, Patryk Małek, Peter Grace, Rodrigo Campos, Sebastian-RG, Simon, Simon Smith.
+
+Thank you!
+
+## Version 0.13.10
+
+New Features:
+
+- Bumped the FRR version used by MetalLB to 8.4.2 ([PR 1829](https://github.com/metallb/metallb/pull/1829))
+- Charts: enable additional controller / speaker labels ([PR 1797](https://github.com/metallb/metallb/pull/1797))
+- l2: exclude common virtual interfaces for announce services ([PR 1767](https://github.com/metallb/metallb/pull/1767))
+- FRR Mode: provide a way to append a piece of configuration ([PR 1863](https://github.com/metallb/metallb/pull/1863))
+- Local Preference validation across multiple advertisements ([PR 1820](https://github.com/metallb/metallb/pull/1820))
+- Charts: support rbacproxy custom pull policy ([PR 1851](https://github.com/metallb/metallb/pull/1851))
+- Add support for large communities ([PR 1898](https://github.com/metallb/metallb/pull/1898))
+- Optimization: on service delete reprocess the services only if the service had an IP assigned ([PR 1945](https://github.com/metallb/metallb/pull/1945))
+- Make the FRR mode the default one when deploying via charts ([PR 1931](https://github.com/metallb/metallb/pull/1931))
+
+Bug Fixes:
+
+- Charts: remove duplicate relabings and metricRelabelings for speaker ([PR 18030](https://github.com/metallb/metallb/pull/1830))
+- Respect NodeNetworkUnavailable ([PR 1759](https://github.com/metallb/metallb/pull/1759))
+- Verify LB ip and address pool annotations compatibility ([PR 1920](https://github.com/metallb/metallb/pull/1920))
+
+This release includes contributions from Andreas Karis, Chok Yip Lau, Chris Privitere, conblem, cyclinder, dependabot[bot], DerFels, Federico Paolinelli, Fish-pro, Guillaume SMAHA, liornoy, Marcelo Guerrero Viveros, Mathew Peterson, Periyasamy Palanisamy, Tobias Klauser, xin.li, yulng. Thank you!
+
+>>>>>>> 2bed9461a (Metrics: add ipv4/6 addresses_in_use_total and addresses_total)
 ## Version 0.13.9
 
 New Features:


### PR DESCRIPTION
Backporting the per ip family allocation metrics