### PR TITLE
frr-k8s via cno job: don't change the csv

### DIFF
--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -164,7 +164,7 @@ fi
 
 NAMESPACE="metallb-system"
 FRRK8S_NAMESPACE="metallb-system"
-if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
+if [[ "$BGP_TYPE" == "frr-k8s-cno" || "$BGP_TYPE" == "frr-k8s" ]]; then
   FRRK8S_NAMESPACE="openshift-frr-k8s"
 fi
 

--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -45,13 +45,6 @@ ESCAPED_KUBERBAC_IMAGE=$(printf '%s\n' "${KUBERBAC_IMAGE_BASE}:${KUBERBAC_IMAGE_
 find . -type f -name "*clusterserviceversion*.yaml" -exec sed -i 's/quay.io\/openshift\/origin-kube-rbac-proxy:.*$/'"$ESCAPED_KUBERBAC_IMAGE"'/g' {} +
 find . -type f -name "*clusterserviceversion*.yaml" -exec sed -r -i 's/name: metallb-operator\..*$/name: metallb-operator.v0.0.0/g' {} +
 
-if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
-  # - Change the metallb operator's CSV to instruct the operator to interact with CNO
-  awk '/DEPLOY_PODMONITORS/ {system("cat frrk8s-cno.patch"); print; next}1' manifests/stable/metallb-operator.clusterserviceversion.yaml  > temp.yaml
-  mv temp.yaml manifests/stable/metallb-operator.clusterserviceversion.yaml
-
-fi
-
 cd -
 
 oc label ns openshift-marketplace --overwrite pod-security.kubernetes.io/enforce=privileged

--- a/openshift-ci/frrk8sdebug_cm.yaml
+++ b/openshift-ci/frrk8sdebug_cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env-overrides
+  namespace: openshift-frr-k8s
+data:
+  frrk8s-loglevel: "--log-level=debug"

--- a/openshift-ci/patchcvo_overridefrrk8s.yaml
+++ b/openshift-ci/patchcvo_overridefrrk8s.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/overrides
+  value: []
+- op: add
+  path: /spec/overrides/-
+  value:
+    kind: Deployment
+    name: network-operator
+    group: apps
+    namespace: openshift-network-operator
+    unmanaged: true
+

--- a/openshift-ci/run_metallb_e2e.sh
+++ b/openshift-ci/run_metallb_e2e.sh
@@ -39,7 +39,7 @@ set -e
 pip3 install --user -r ./../dev-env/requirements.txt
 
 FRRK8S_NAMESPACE=""
-if [[ "$BGP_TYPE" == "frr-k8s-cno" ]]; then
+if [[ "$BGP_TYPE" == "frr-k8s-cno" || "$BGP_TYPE" == "frr-k8s" ]]; then
   FRRK8S_NAMESPACE="--frr-k8s-namespace=openshift-frr-k8s"
 fi
 


### PR DESCRIPTION
We are enabling it by default, so there is no point in setting the env variables.
Also, moving the frr-k8s job to work as frr-k8s-cno as it's going to be the only operating mode (and we want to see CI passing). Next step is going to be removing one of the two jobs as now they are identical.