### PR TITLE
OCPBUGS-46554: frr-k8s: Make sure no duplicates prefix are passed to backend

### DIFF
--- a/internal/bgp/frrk8s/frrk8s_test.go
+++ b/internal/bgp/frrk8s/frrk8s_test.go
@@ -482,6 +482,59 @@ func TestSingleAdvertisement(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+func TestTwoAdvertisementsWithSamePrefix(t *testing.T) {
+	l := log.NewNopLogger()
+	sessionManager := newTestSessionManager(t)
+	session, err := sessionManager.NewSession(l,
+		bgp.SessionParameters{
+			PeerAddress:   "10.2.2.254:179",
+			SourceAddress: net.ParseIP("10.1.1.254"),
+			MyASN:         100,
+			RouterID:      net.ParseIP("10.1.1.254"),
+			PeerASN:       200,
+			HoldTime:      ptr.To(time.Second),
+			KeepAliveTime: ptr.To(time.Second),
+			Password:      "password",
+			CurrentNode:   "hostname",
+			EBGPMultiHop:  true,
+			SessionName:   "test-peer"})
+	if err != nil {
+		t.Fatalf("Could not create session: %s", err)
+	}
+	defer session.Close()
+
+	prefix := &net.IPNet{
+		IP:   net.ParseIP("172.16.1.10"),
+		Mask: classCMask,
+	}
+	communities := []community.BGPCommunity{}
+	community1, _ := community.New("1111:2222")
+	communities = append(communities, community1)
+	community2, _ := community.New("3333:4444")
+	communities = append(communities, community2)
+	adv := &bgp.Advertisement{
+		Prefix:      prefix,
+		Communities: communities,
+		LocalPref:   300,
+		Peers:       []string{"peer1"},
+	}
+	adv2 := &bgp.Advertisement{
+		Prefix:      prefix,
+		Communities: communities,
+		LocalPref:   300,
+	}
+	advs := []*bgp.Advertisement{adv, adv2}
+	rand.Shuffle(len(advs), func(i, j int) {
+		advs[i], advs[j] = advs[j], advs[i]
+	})
+	err = session.Set(advs[0], advs[1])
+	if err != nil {
+		t.Fatalf("Could not advertise prefix: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
 func TestSingleAdvertisementNoRouterID(t *testing.T) {
 	l := log.NewNopLogger()
 	sessionManager := newTestSessionManager(t)

--- a/internal/bgp/frrk8s/testdata/TestTwoAdvertisementsWithSamePrefix.golden
+++ b/internal/bgp/frrk8s/testdata/TestTwoAdvertisementsWithSamePrefix.golden
@@ -1,0 +1,71 @@
+{
+    "metadata": {
+        "name": "metallb-testnodename",
+        "namespace": "testnamespace",
+        "creationTimestamp": null
+    },
+    "spec": {
+        "bgp": {
+            "routers": [
+                {
+                    "asn": 100,
+                    "id": "10.1.1.254",
+                    "neighbors": [
+                        {
+                            "asn": 200,
+                            "address": "10.2.2.254",
+                            "port": 179,
+                            "password": "password",
+                            "passwordSecret": {},
+                            "holdTime": "1s",
+                            "keepaliveTime": "1s",
+                            "ebgpMultiHop": true,
+                            "toAdvertise": {
+                                "allowed": {
+                                    "prefixes": [
+                                        "172.16.1.10/24"
+                                    ]
+                                },
+                                "withLocalPref": [
+                                    {
+                                        "prefixes": [
+                                            "172.16.1.10/24"
+                                        ],
+                                        "localPref": 300
+                                    }
+                                ],
+                                "withCommunity": [
+                                    {
+                                        "prefixes": [
+                                            "172.16.1.10/24"
+                                        ],
+                                        "community": "1111:2222"
+                                    },
+                                    {
+                                        "prefixes": [
+                                            "172.16.1.10/24"
+                                        ],
+                                        "community": "3333:4444"
+                                    }
+                                ]
+                            },
+                            "toReceive": {
+                                "allowed": {}
+                            }
+                        }
+                    ],
+                    "prefixes": [
+                        "172.16.1.10/24"
+                    ]
+                }
+            ]
+        },
+        "raw": {},
+        "nodeSelector": {
+            "matchLabels": {
+                "kubernetes.io/hostname": "testnodename"
+            }
+        }
+    },
+    "status": {}
+}


### PR DESCRIPTION
clean cherry-pick from 4.18

