### PR TITLE
OpenShift only: skip Unnumbered e2es

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -9,7 +9,7 @@ FRRK8S_DIR="$(dirname $(readlink -f $0))/../../frr"
 KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
 pushd $FRRK8S_DIR
 
-SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips"
+SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips\|Unnumbered.*"
 SKIP="$SKIP\|should.*block.*always.*block.*cidr"
 
 if [[ "$BGP_TYPE" == "frr-k8s" ]]; then


### PR DESCRIPTION
skipping unnumbered tests since we don't have a setup for it in dev-scripts