### PR TITLE
Lower the routing table to be used for the test VRF

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -42,7 +42,7 @@ pods=$(oc get pods -l "app=frr-k8s" -n $FRRK8S_NAMESPACE -o jsonpath='{.items[*]
 echo "creating vrfs in pods $pods"
 for pod in $pods; do
   echo "creating vrf in pod $pod"
-  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link add red type vrf table 1100
+  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link add red type vrf table 900
   oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link set red up
 done
 


### PR DESCRIPTION
OVN-K will interpret any VRF with a routing table higher than 1000 as its own, and will delete those which do not have a configured ovnk counterpart.

This means that the vrf created to perform the test will be deleted before we run the test and the vrf leaking test will fail.
