### PR TITLE
OCPBUGS-51175: Fix the handling of readyness conditions of endpointslices

### DIFF
--- a/internal/k8s/epslices/endpoint_slices.go
+++ b/internal/k8s/epslices/endpoint_slices.go
@@ -11,16 +11,15 @@ import (
 
 const SlicesServiceIndexName = "ServiceName"
 
-// IsConditionServing tells if the conditions represent a serving state, deferring
-// to ready state if serving == nil.
-func IsConditionServing(conditions discovery.EndpointConditions) bool {
-	if conditions.Serving == nil {
-		if conditions.Ready == nil {
-			return true
-		}
-		return *conditions.Ready
+// EndpointCanServe tells if the conditions represent a ready state or serving state is ready.
+func EndpointCanServe(conditions discovery.EndpointConditions) bool {
+	if conditions.Ready == nil || *conditions.Ready {
+		return true
 	}
-	return *conditions.Serving
+	if conditions.Serving != nil && *conditions.Serving {
+		return true
+	}
+	return false
 }
 
 func ServiceKeyForSlice(endpointSlice *discovery.EndpointSlice) (types.NamespacedName, error) {

--- a/internal/k8s/epslices/endpoint_slices_test.go
+++ b/internal/k8s/epslices/endpoint_slices_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package epslices
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/discovery/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestIsConditionReadyOrServing(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions v1.EndpointConditions
+		want       bool
+	}{
+		{
+			name: "Is Ready",
+			conditions: v1.EndpointConditions{
+				Ready: ptr.To(true),
+			},
+			want: true,
+		},
+		{
+			name: "Is Serving",
+			conditions: v1.EndpointConditions{
+				Serving: ptr.To(true),
+			},
+			want: true,
+		},
+		{
+			name: "Is Ready but not serving",
+			conditions: v1.EndpointConditions{
+				Ready:   ptr.To(true),
+				Serving: ptr.To(false),
+			},
+			want: true,
+		},
+		{
+			name:       "Ready and Serving not set",
+			conditions: v1.EndpointConditions{},
+			want:       true,
+		},
+		{
+			name: "Ready not set and not serving",
+			conditions: v1.EndpointConditions{
+				Serving: ptr.To(false),
+			},
+			want: true,
+		},
+		{
+			name: "Not Ready",
+			conditions: v1.EndpointConditions{
+				Ready: ptr.To(false),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EndpointCanServe(tt.conditions); got != tt.want {
+				t.Errorf("EndpointCanServe() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -125,13 +125,13 @@ func hasHealthyEndpoint(eps []discovery.EndpointSlice, filterNode func(*string) 
 				continue
 			}
 			for _, addr := range ep.Addresses {
-				if _, ok := ready[addr]; !ok && epslices.IsConditionServing(ep.Conditions) {
+				if _, ok := ready[addr]; !ok && epslices.EndpointCanServe(ep.Conditions) {
 					// Only set true if nothing else has expressed an
 					// opinion. This means that false will take precedence
 					// if there's any unready ports for a given endpoint.
 					ready[addr] = true
 				}
-				if !epslices.IsConditionServing(ep.Conditions) {
+				if !epslices.EndpointCanServe(ep.Conditions) {
 					ready[addr] = false
 				}
 			}

--- a/speaker/bgp_controller_test.go
+++ b/speaker/bgp_controller_test.go
@@ -618,6 +618,41 @@ func TestBGPSpeakerEPSlices(t *testing.T) {
 		},
 
 		{
+			desc:     "Endpoint list contains ready but not serving endpoints",
+			balancer: "test1",
+			svc: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type:                  "LoadBalancer",
+					ExternalTrafficPolicy: "Cluster",
+				},
+				Status: statusAssigned("10.20.30.1"),
+			},
+			eps: []discovery.EndpointSlice{
+				{
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{
+								"2.3.4.5",
+							},
+							NodeName: ptr.To("iris"),
+							Conditions: discovery.EndpointConditions{
+								Ready:   ptr.To(true),
+								Serving: ptr.To(false),
+							},
+						},
+					},
+				},
+			},
+			wantAds: map[string][]*bgp.Advertisement{
+				"1.2.3.4:0": {
+					{
+						Prefix: ipnet("10.20.30.1/32"),
+					},
+				},
+			},
+		},
+
+		{
 			desc: "Multiple advertisement config",
 			config: &config.Config{
 				Peers: map[string]*config.Peer{

--- a/speaker/layer2_controller.go
+++ b/speaker/layer2_controller.go
@@ -54,7 +54,7 @@ func usableNodes(eps []discovery.EndpointSlice, speakers map[string]bool) []stri
 	usable := map[string]bool{}
 	for _, slice := range eps {
 		for _, ep := range slice.Endpoints {
-			if !epslices.IsConditionServing(ep.Conditions) {
+			if !epslices.EndpointCanServe(ep.Conditions) {
 				continue
 			}
 			if ep.NodeName == nil {
@@ -204,7 +204,7 @@ func nodesWithActiveSpeakers(speakers map[string]bool) []string {
 func activeEndpointExists(eps []discovery.EndpointSlice) bool {
 	for _, slice := range eps {
 		for _, ep := range slice.Endpoints {
-			if !epslices.IsConditionServing(ep.Conditions) {
+			if !epslices.EndpointCanServe(ep.Conditions) {
 				continue
 			}
 			return true

--- a/speaker/layer2_controller_test.go
+++ b/speaker/layer2_controller_test.go
@@ -222,6 +222,37 @@ func TestUsableNodesEPSlices(t *testing.T) {
 			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
 			cExpectedResult: []string{"iris1", "iris2"},
 		},
+		{
+			desc: "Two endpoints, different hosts, ready but not serving",
+			eps: []discovery.EndpointSlice{
+				{
+					Endpoints: []discovery.Endpoint{
+						{
+							Addresses: []string{
+								"2.3.4.5",
+							},
+							NodeName: ptr.To("iris1"),
+							Conditions: discovery.EndpointConditions{
+								Ready:   ptr.To(true),
+								Serving: ptr.To(false),
+							},
+						},
+						{
+							Addresses: []string{
+								"2.3.4.15",
+							},
+							NodeName: ptr.To("iris2"),
+							Conditions: discovery.EndpointConditions{
+								Ready:   ptr.To(true),
+								Serving: ptr.To(false),
+							},
+						},
+					},
+				},
+			},
+			usableSpeakers:  map[string]bool{"iris1": true, "iris2": true},
+			cExpectedResult: []string{"iris1", "iris2"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
instead of looking at the serving condition first, we look at the ready condition which has precendence. This allows metallb to respect the publishNotReadyAddresses field of the services.
