### PR TITLE
Lower the routing table to be used for the test VRF

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -42,7 +42,7 @@ pods=$(oc get pods -l "app=frr-k8s" -n $FRRK8S_NAMESPACE -o jsonpath='{.items[*]
 echo "creating vrfs in pods $pods"
 for pod in $pods; do
   echo "creating vrf in pod $pod"
-  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link add red type vrf table 1100
+  oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link add red type vrf table 900
   oc exec $pod -n $FRRK8S_NAMESPACE -c frr -- ip link set red up
 done
 


### PR DESCRIPTION
OVN-K will interpret any VRF with a routing table higher than 1000 as its own, and will delete those which do not have a configured ovnk counterpart.

This means that the vrf created to perform the test will be deleted before we run the test and the vrf leaking test will fail.

Signed-off-by: Federico Paolinelli <fpaoline@redhat.com>
(cherry picked from commit 3ef9102a47fb77ab7a88e5e5d0f93f86a864443f)

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
