### PR TITLE
OpenShift only: skip BGPSessionState VRF test

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -10,7 +10,7 @@ KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
 pushd $FRRK8S_DIR
 
 SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips\|.*Unnumbered.*"
-SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*"
+SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*|BGPSessionState.*VRF"
 
 if [[ "$BGP_TYPE" == "frr-k8s" ]]; then
   SKIP="$SKIP\|metrics"  # because when running as a metallb pod the metrics are overridden.


### PR DESCRIPTION
Since we don't run any VRF containers the test doesn't make sense, and it panics because it tries to access an element from the empty containers slice:
```
BGPSessionState BGP and BFD Each node manages its statuses [It] IPV4 - VRF
/root/dev-scripts/frr/e2etests/tests/bgp_session_status.go:348
  [PANICKED] Test Panicked
  In [It] at: /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.11.linux-amd64/src/runtime/panic.go:114 @ 04/04/25 05:28:19.433
  runtime error: index out of range [0] with length 0
```
