### PR TITLE
OpenShift only: fix the skip of BGPSessionState VRF test

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -10,7 +10,7 @@ KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
 pushd $FRRK8S_DIR
 
 SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips\|.*Unnumbered.*"
-SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*|BGPSessionState.*VRF"
+SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*\|BGPSessionState.*VRF"
 
 if [[ "$BGP_TYPE" == "frr-k8s" ]]; then
   SKIP="$SKIP\|metrics"  # because when running as a metallb pod the metrics are overridden.


### PR DESCRIPTION
Missed "\", failing with:
```
bash: line 1: BGPSessionState.*VRF|IPV6|DUALSTACK: command not found
```
