### PR TITLE
Openshift-Only: skip graceful restart in the frr-k8s e2e tests

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -10,7 +10,8 @@ KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
 pushd $FRRK8S_DIR
 
 SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips"
-SKIP="$SKIP\|should.*block.*always.*block.*cidr"
+SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*"
+SKIP="$SKIP\|.*with graceful restart.*"
 
 if [[ "$BGP_TYPE" == "frr-k8s" ]]; then
   SKIP="$SKIP\|metrics"  # because when running as a metallb pod the metrics are overridden.


### PR DESCRIPTION
The GR is abandoned OCP feature and those tests are failing downstream.

```
[FAIL] Session Session parameters Establishes sessions with graceful restart [It] IPV4
/root/dev-scripts/frr/e2etests/tests/session.go:259
[FAIL] Establish BGP session with EnableGracefulRestart When restarting the frrk8s deamon pods external BGP peer maintains routes [It] IPV4
/root/dev-scripts/frr/e2etests/tests/graceful_restart.go:128
```

