### PR TITLE
OpenShift only: skip existing BGPSessionState e2es

### DIFF
--- a/openshift-ci/run_frrk8s_e2e.sh
+++ b/openshift-ci/run_frrk8s_e2e.sh
@@ -10,7 +10,7 @@ KUBECONFIG=$(readlink -f ../../ocp/ostest/auth/kubeconfig)
 pushd $FRRK8S_DIR
 
 SKIP="Leaked.*advertising\|receive.*ips.*from.*some\|VRF.*Advertise.*a.*subset.*of.*ips\|.*Unnumbered.*"
-SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*\|BGPSessionState.*VRF"
+SKIP="$SKIP\|should.*block.*always.*block.*cidr\|.*EnableGracefulRestart.*\|BGPSessionState.*Each.*node.*manages.*its.*statuses.*"
 
 if [[ "$BGP_TYPE" == "frr-k8s" ]]; then
   SKIP="$SKIP\|metrics"  # because when running as a metallb pod the metrics are overridden.


### PR DESCRIPTION
The tests aren't compatible with d/s because the poll-interval for the status sidecar container is too large. We'll skip these tests for now and add a smoke test for the feature.

