### PR TITLE
Openshift CI: enable frrk8s debug logs

### DIFF
--- a/openshift-ci/common.sh
+++ b/openshift-ci/common.sh
@@ -21,3 +21,19 @@ wait_for_pods() {
   timeout 5m bash -c "until oc -n $namespace wait --for=condition=Ready --all pods --timeout 2m; do sleep 5; done"
   echo "pods for $namespace are ready"
 }
+
+enable_frr_k8s_debug() {
+  local FRRK8S_NAMESPACE="openshift-frr-k8s"
+  echo "Enabling debug for frr-k8s"
+  oc create ns ${FRRK8S_NAMESPACE} || true
+
+  oc apply -f - <<EOF
+apiVersion: v1  
+kind: ConfigMap  
+metadata:  
+  name: env-overrides  
+  namespace: ${FRRK8S_NAMESPACE}
+data:  
+  frrk8s-loglevel: "--log-level=debug"
+EOF
+}

--- a/openshift-ci/deploy_frr_k8s_from_cno.sh
+++ b/openshift-ci/deploy_frr_k8s_from_cno.sh
@@ -10,6 +10,8 @@ FRR_IMAGE_TAG=${FRR_IMAGE_TAG:-"metallb-frr"}
 
 FRRK8S_NAMESPACE="openshift-frr-k8s"
 
+enable_frr_k8s_debug
+
 oc patch networks.operator.openshift.io cluster --type json  -p '[{"op": "add", "path": "/spec/additionalRoutingCapabilities", "value": {providers: ["FRR"]}}]'
 
 wait_for_pods $FRRK8S_NAMESPACE "app=frr-k8s"

--- a/openshift-ci/deploy_metallb.sh
+++ b/openshift-ci/deploy_metallb.sh
@@ -139,6 +139,8 @@ fi
 oc label ns openshift-marketplace --overwrite pod-security.kubernetes.io/enforce=baseline
 oc label ns metallb-system openshift.io/cluster-monitoring=true
 
+enable_frr_k8s_debug
+
 if [[ -z "${BGP_TYPE}" ]]; then
 oc apply -f - <<EOF
 apiVersion: metallb.io/v1beta1


### PR DESCRIPTION
Enabling debug logs as we might need them when triaging CI failures.
