### PR TITLE
OCPBUGS-59967: align to upstream

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,6 +14,7 @@
 | Vendor | SUSE | 2023 | [link](https://www.suse.com) | MetalLB is a core part of the SUSE Edge solution serving as a LoadBalancer on Bare Metal, as well as load balancing the Kubernetes API in highly available topologies |
 | Vendor | Nokia EDA | 2024 | [link](https://docs.eda.dev) | MetalLB implements the LoadBalancer controller role in the Nokia Event Driven Automation (EDA) product|
 | End-user | Kiratech S.p.A. | 2022 | [link](https://www.kiratech.it/) | MetalLB is the LoadBalancer reference technology in our training courses laboratories, which are [public and published under MIT license](https://github.com/kiratech/labs) |
+| End-user | Westnet | 2023 | [link](https://www.westnet.ie/) | We use MetalLB as the LoadBalancer for our in-house and public-facing applications, built on a self-hosted [Talos Linux](https://talos.dev) cluster |
 
 
 ### Adopter Types

--- a/charts/metallb/README.md
+++ b/charts/metallb/README.md
@@ -136,6 +136,9 @@ Kubernetes: `>= 1.19.0-0`
 | speaker.image.pullPolicy | string | `nil` |  |
 | speaker.image.repository | string | `"quay.io/metallb/speaker"` |  |
 | speaker.image.tag | string | `nil` |  |
+| speaker.initContainers.cpFrrFiles.resources | object | `{}` |  |
+| speaker.initContainers.cpMetrics.resources | object | `{}` |  |
+| speaker.initContainers.cpReloader.resources | object | `{}` |  |
 | speaker.labels | object | `{}` |  |
 | speaker.livenessProbe.enabled | bool | `true` |  |
 | speaker.livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/metallb/templates/speaker.yaml
+++ b/charts/metallb/templates/speaker.yaml
@@ -216,6 +216,10 @@ spec:
               mountPath: /tmp/frr
             - name: frr-conf
               mountPath: /etc/frr
+          {{- with .Values.speaker.initContainers.cpFrrFiles.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         # Copies the reloader to the shared volume between the speaker and reloader.
         - name: cp-reloader
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -223,6 +227,10 @@ spec:
           volumeMounts:
             - name: reloader
               mountPath: /etc/frr_reloader
+          {{- with .Values.speaker.initContainers.cpReloader.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         # Copies the metrics exporter
         - name: cp-metrics
           image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
@@ -230,6 +238,10 @@ spec:
           volumeMounts:
             - name: metrics
               mountPath: /etc/frr_metrics
+          {{- with .Values.speaker.initContainers.cpMetrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       shareProcessNamespace: true
       {{- end }}
       containers:
@@ -464,7 +476,7 @@ spec:
             value: /dev/null
         ports:
           - containerPort: {{ .Values.speaker.frr.metricsPort }}
-            name: monitoring
+            name: frrmetrics
         volumeMounts:
           - name: frr-sockets
             mountPath: /var/run/frr

--- a/charts/metallb/values.schema.json
+++ b/charts/metallb/values.schema.json
@@ -414,6 +414,29 @@
                 "resources": { "type": "object" }
               }
             },
+            "initContainers": {
+              "type": "object",
+              "properties": {
+                "cpFrrFiles": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                },
+                "cpReloader": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                },
+                "cpMetrics": {
+                  "type": "object",
+                  "properties": {
+                    "resources": { "type": "object" }
+                  }
+                }
+              }
+            },
             "extraContainers": {
               "type": "array",
               "items": {

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -352,6 +352,14 @@ speaker:
   frrMetrics:
     resources: {}
 
+  initContainers:
+    cpFrrFiles:
+      resources: {}
+    cpReloader:
+      resources: {}
+    cpMetrics:
+      resources: {}
+
   extraContainers: []
 
 crds:

--- a/config/frr/speaker-patch.yaml
+++ b/config/frr/speaker-patch.yaml
@@ -110,7 +110,7 @@ spec:
               value: /dev/null
           ports:
             - containerPort: 7473
-              name: monitoring
+              name: frrmetrics
           volumeMounts:
             - name: frr-sockets
               mountPath: /var/run/frr

--- a/config/manifests/metallb-frr-prometheus.yaml
+++ b/config/manifests/metallb-frr-prometheus.yaml
@@ -2253,7 +2253,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7473
-          name: monitoring
+          name: frrmetrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/config/manifests/metallb-frr.yaml
+++ b/config/manifests/metallb-frr.yaml
@@ -2076,7 +2076,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7473
-          name: monitoring
+          name: frrmetrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/configmaptocrs/Dockerfile
+++ b/configmaptocrs/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.3 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.4 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.3 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.4 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/internal/bgp/bgp.go
+++ b/internal/bgp/bgp.go
@@ -83,6 +83,7 @@ type SessionParameters struct {
 	VRFName                string
 	SessionName            string
 	DualStackAddressFamily bool
+	DisableMP              bool
 }
 type SessionManager interface {
 	NewSession(logger log.Logger, args SessionParameters) (Session, error)

--- a/internal/bgp/frrk8s/frrk8s.go
+++ b/internal/bgp/frrk8s/frrk8s.go
@@ -271,6 +271,7 @@ func (sm *sessionManager) updateConfig() error {
 				EnableGracefulRestart:  s.GracefulRestart,
 				EBGPMultiHop:           s.EBGPMultiHop,
 				DualStackAddressFamily: s.DualStackAddressFamily,
+				DisableMP:              s.DisableMP,
 				ToAdvertise: frrv1beta1.Advertise{
 					Allowed: frrv1beta1.AllowedOutPrefixes{
 						Prefixes: make([]string, 0),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,8 @@ type Peer struct {
 	VRF string
 	// Option to advertise v4 addresses over v6 sessions and viceversa.
 	DualStackAddressFamily bool
+	// Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+	DisableMP bool
 }
 
 // Pool is the configuration of an IP address pool.
@@ -484,6 +486,7 @@ func peerFromCR(p metallbv1beta2.BGPPeer, passwordSecrets map[string]corev1.Secr
 		EBGPMultiHop:           p.Spec.EBGPMultiHop,
 		VRF:                    p.Spec.VRFName,
 		DualStackAddressFamily: p.Spec.DualStackAddressFamily,
+		DisableMP:              p.Spec.DisableMP,
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3633,6 +3633,39 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "peer with DisableMP field",
+			crs: ClusterResources{
+				Peers: []v1beta2.BGPPeer{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "peer1",
+						},
+						Spec: v1beta2.BGPPeerSpec{
+							MyASN:     42,
+							ASN:       142,
+							Address:   "1.2.3.4",
+							DisableMP: true,
+						},
+					},
+				},
+			},
+			want: &Config{
+				Peers: map[string]*Peer{
+					"peer1": {
+						Name:                   "peer1",
+						MyASN:                  42,
+						ASN:                    142,
+						Addr:                   net.ParseIP("1.2.3.4"),
+						NodeSelectors:          []labels.Selector{labels.Everything()},
+						DisableMP:              true,
+						DualStackAddressFamily: false,
+					},
+				},
+				Pools:       &Pools{ByName: map[string]*Pool{}},
+				BFDProfiles: map[string]*BFDProfile{},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/speaker/Dockerfile
+++ b/speaker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.3 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.24.4 AS builder
 WORKDIR $GOPATH/go.universe.tf/metallb
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -265,6 +265,7 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 				SessionName:            p.cfg.Name,
 				VRFName:                p.cfg.VRF,
 				DualStackAddressFamily: p.cfg.DualStackAddressFamily,
+				DisableMP:              p.cfg.DisableMP, //nolint:staticcheck // SA1019: intentionally using deprecated field for translation
 			}
 			sessionParams.Password, sessionParams.PasswordRef = passwordForSession(p.cfg, c.bgpType, c.secretHandling)
 


### PR DESCRIPTION
Align to upstream, brings forwarding the disablemp value to frr-k8s even if it's not being used anymore.
Needed as Ovn-k expects it to be set