### PR TITLE
Openshift CI: env setup for dualstack tests

### DIFF
--- a/openshift-ci/common.sh
+++ b/openshift-ci/common.sh
@@ -46,3 +46,7 @@ wait_for_csv() {
   timeout 5m bash -c "until oc get csv -n $namespace $csv; do sleep 5; done"
   oc wait --for jsonpath='{.status.phase}'=Succeeded csv/"$csv" -n "$namespace" --timeout=300s
 }
+
+nthhost() {
+  python3 -c "from ipaddress import ip_network; print(ip_network('$1', strict=False)[$2])"
+}

--- a/openshift-ci/run_metallb_e2e.sh
+++ b/openshift-ci/run_metallb_e2e.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/bash
 set -euo pipefail
 
+metallb_dir="$(dirname $(readlink -f $0))"
+source ${metallb_dir}/common.sh
+
 IP_STACK=$1
 
 # need to skip L2 metrics / node selector test because the pod that's running the tests is not
@@ -24,7 +27,7 @@ elif [ "${IP_STACK}" = "v6" ]; then
 elif [ "${IP_STACK}" = "v4v6" ]; then
 	SKIP="$SKIP|IPV6"
 	export PROVISIONING_HOST_EXTERNAL_IPV4=${PROVISIONING_HOST_EXTERNAL_IP}
-	export PROVISIONING_HOST_EXTERNAL_IPV6=1111:1:1::1
+	export PROVISIONING_HOST_EXTERNAL_IPV6=$(nthhost "$EXTERNAL_SUBNET_V6" 1)
 fi
 echo "Skipping ${SKIP}"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
 /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**: Configure the correct IPv6 addresse of external frr for Dualstack (v4v6) MetalLB e2e in OpenShift CI 

- Adds an nthhost helper in openshift-ci/common.sh that returns the Nth host in a CIDR via Python’s ipaddress.ip_network.
- For IP_STACK=v4v6, derives PROVISIONING_HOST_EXTERNAL_IPV6 from EXTERNAL_SUBNET_V6 (host index 1) instead of the hardcoded dummy.


**Special notes for your reviewer**: 
nthhost matches the helper used in openshift-metal3/dev-scripts (network.sh), which already exports EXTERNAL_SUBNET_V6.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dual-stack network setup by selecting the external IPv6 provisioning address from the configured subnet.
  * Added support for networks with non-strict address notation, improving address resolution during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->